### PR TITLE
Templates & IO

### DIFF
--- a/lib/managers/photos_manager.dart
+++ b/lib/managers/photos_manager.dart
@@ -44,7 +44,8 @@ abstract class PhotosManagerBase with Store {
   bool get showLiveViewBackground => photos.isEmpty && captureMode == CaptureMode.single;
 
   Directory get outputDir => Directory(SettingsManagerBase.instance.settings.output.localFolder);
-  int? photoNumber;
+  int photoNumber = 0;
+  bool photoNumberChecked = false;
   String baseName = "MomentoBooth-image";
  
   Iterable<Uint8List> get chosenPhotos => chosen.map((choice) => photos[choice]);
@@ -52,16 +53,20 @@ abstract class PhotosManagerBase with Store {
   PhotosManagerBase._internal();
 
   @action
-  void reset() {
+  void reset({bool advance = true}) {
     photos.clear();
     chosen.clear();
     captureMode = CaptureMode.single;
+    if (advance) { photoNumber++; }
   }
 
   @action
   Future<File?> writeOutput() async {
     if (instance.outputImage == null) return null;
-    photoNumber ??= await findLastImageNumber()+1;
+    if (!photoNumberChecked) {
+      photoNumber = await findLastImageNumber()+1;
+      photoNumberChecked = true;
+    }
     final extension = SettingsManagerBase.instance.settings.output.exportFormat.name.toLowerCase();
     final filePath = join(outputDir.path, '$baseName-${photoNumber.toString().padLeft(4, '0')}.$extension');
     File file = await File(filePath).create();

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -20,6 +20,7 @@ class Settings with _$Settings implements TomlEncodableValue {
 
   const factory Settings({
     required int captureDelaySeconds,
+    required bool singlePhotoIsCollage,
     required String templatesFolder,
     required HardwareSettings hardware,
     required OutputSettings output,
@@ -28,6 +29,7 @@ class Settings with _$Settings implements TomlEncodableValue {
   factory Settings.withDefaults() {
     return Settings(
       captureDelaySeconds: 5,
+      singlePhotoIsCollage: true,
       templatesFolder: _getHome(),
       hardware: HardwareSettings.withDefaults(),
       output: OutputSettings.withDefaults(),

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -20,6 +20,7 @@ class Settings with _$Settings implements TomlEncodableValue {
 
   const factory Settings({
     required int captureDelaySeconds,
+    required String templatesFolder,
     required HardwareSettings hardware,
     required OutputSettings output,
   }) = _Settings;
@@ -27,6 +28,7 @@ class Settings with _$Settings implements TomlEncodableValue {
   factory Settings.withDefaults() {
     return Settings(
       captureDelaySeconds: 5,
+      templatesFolder: _getHome(),
       hardware: HardwareSettings.withDefaults(),
       output: OutputSettings.withDefaults(),
     );

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -23,15 +23,17 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
       children: [
         // Is this very pretty? No. But it works 😅
         FittedBox(
-          child: SizedBox(
-            height: 1000,
-            child: PhotoCollage(
-              key: viewModel.collageKey,
-              aspectRatio: 2/3
+          child: Transform.translate(
+            offset: Offset(3000, 0),
+            child: SizedBox(
+              height: 1000,
+              child: PhotoCollage(
+                key: viewModel.collageKey,
+                aspectRatio: 2/3
+              ),
             ),
           ),
         ),
-        LiveView(),
         Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_rust_bridge_example/views/base/screen_view_base.dart';
 import 'package:flutter_rust_bridge_example/views/capture_screen/capture_screen_controller.dart';
 import 'package:flutter_rust_bridge_example/views/capture_screen/capture_screen_view_model.dart';
 import 'package:flutter_rust_bridge_example/views/custom_widgets/capture_counter.dart';
+import 'package:flutter_rust_bridge_example/views/custom_widgets/photo_collage.dart';
 import 'package:flutter_rust_bridge_example/views/custom_widgets/wrappers/live_view_background.dart';
 
 class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureScreenController> {
@@ -20,6 +21,16 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
     return Stack(
       fit: StackFit.expand,
       children: [
+        // Is this very pretty? No. But it works 😅
+        FittedBox(
+          child: SizedBox(
+            height: 1000,
+            child: PhotoCollage(
+              key: viewModel.collageKey,
+              aspectRatio: 2/3
+            ),
+          ),
+        ),
         LiveView(),
         Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -86,8 +86,12 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   void captureAndGetPhoto() async {
     final image = await capturer.captureAndGetPhoto();
     PhotosManagerBase.instance.photos.add(image);
-    // PhotosManagerBase.instance.outputImage = image;
-    await captureCollage();
+    if (SettingsManagerBase.instance.settings.singlePhotoIsCollage) {
+      await captureCollage();
+    } else {
+      PhotosManagerBase.instance.outputImage = image;
+      await PhotosManagerBase.instance.writeOutput();
+    }
     captureComplete = true;
     navigateAfterCapture();
   }

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/animation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_rust_bridge_example/hardware_control/photo_capturing/live_view_stream_snapshot_capturer.dart';
 import 'package:flutter_rust_bridge_example/hardware_control/photo_capturing/photo_capture_method.dart';
 import 'package:flutter_rust_bridge_example/hardware_control/photo_capturing/sony_remote_photo_capture.dart';
@@ -6,6 +9,7 @@ import 'package:flutter_rust_bridge_example/managers/photos_manager.dart';
 import 'package:flutter_rust_bridge_example/managers/settings_manager.dart';
 import 'package:flutter_rust_bridge_example/views/base/screen_view_model_base.dart';
 import 'package:flutter_rust_bridge_example/models/settings.dart';
+import 'package:flutter_rust_bridge_example/views/custom_widgets/photo_collage.dart';
 import 'package:mobx/mobx.dart';
 
 part 'capture_screen_view_model.g.dart';
@@ -37,6 +41,24 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
 
   @computed
   Duration get flashAnimationDuration => showFlash ? const Duration(milliseconds: 50) : const Duration(milliseconds: 2500);
+  
+  /// Global key for controlling the slider widget.
+  final GlobalKey<PhotoCollageState> collageKey = GlobalKey<PhotoCollageState>();
+
+  Future<File?> captureCollage() async {
+    PhotosManagerBase.instance.chosen.clear();
+    PhotosManagerBase.instance.chosen.add(0);
+    final stopwatch = Stopwatch()..start();
+    final pixelRatio = SettingsManagerBase.instance.settings.output.resolutionMultiplier;
+    final format = SettingsManagerBase.instance.settings.output.exportFormat;
+    final jpgQuality = SettingsManagerBase.instance.settings.output.jpgQuality;
+    await Future.delayed(Duration(milliseconds: 100));
+    PhotosManagerBase.instance.outputImage = await collageKey.currentState!.getCollageImage(pixelRatio: pixelRatio, format: format, jpgQuality: jpgQuality);
+    print('captureCollage() executed in ${stopwatch.elapsed}');
+    print("Written collage image to output image memory");
+    
+    return await PhotosManagerBase.instance.writeOutput();
+  }
 
   CaptureScreenViewModelBase({
     required super.contextAccessor,
@@ -48,6 +70,8 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     }
     Future.delayed(photoDelay).then((_) => captureAndGetPhoto());
   }
+
+  String get outputFolder => SettingsManagerBase.instance.settings.output.localFolder;
 
   void onCounterFinished() async {
     showFlash = true;
@@ -62,7 +86,8 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   void captureAndGetPhoto() async {
     final image = await capturer.captureAndGetPhoto();
     PhotosManagerBase.instance.photos.add(image);
-    PhotosManagerBase.instance.outputImage = image;
+    // PhotosManagerBase.instance.outputImage = image;
+    await captureCollage();
     captureComplete = true;
     navigateAfterCapture();
   }

--- a/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_rust_bridge_example/managers/photos_manager.dart';
 import 'package:flutter_rust_bridge_example/managers/settings_manager.dart';
@@ -38,8 +36,8 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     PhotosManagerBase.instance.outputImage = await collageKey.currentState!.getCollageImage(pixelRatio: pixelRatio, format: format, jpgQuality: jpgQuality);
     print('captureCollage() executed in ${stopwatch.elapsed}');
     print("Written collage image to output image memory");
-    File file = await File('$outputFolder/MomentoBooth-image.${format.name.toLowerCase()}').create();
-    await file.writeAsBytes(PhotosManagerBase.instance.outputImage!);
+    
+    PhotosManagerBase.instance.writeOutput();
   }
 
   void onContinueTap() {

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -95,7 +95,9 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
                         fit: StackFit.expand,
                         children: [
                           ColoredBox(color: Color(0x80000000)),
-                          Center(child: Icon(Icons.check, size: 80, color: Color(0xFFFFFFFF),),),
+                          Center(
+                            child: Text((PhotosManagerBase.instance.chosen.indexOf(i)+1).toString(), style: theme.subTitleStyle,),
+                          ),
                         ],
                       ),
                     )

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -77,15 +77,12 @@ class PhotoCollageState extends State<PhotoCollage> {
   };
   
   void findTemplates() async {
-    print("Finding templates");
     for (int i = 0; i <= 4; i++) {
       final frontTemplate = await _templateResolver(TemplateKind.front, i);
       final backTemplate = await _templateResolver(TemplateKind.back, i);
       templates[TemplateKind.front]?[i] = frontTemplate;
       templates[TemplateKind.back]?[i] = backTemplate;
     }
-    print("Concluded template search");
-    // print(templates);
     setInitialized([true]);
   }
 
@@ -123,8 +120,6 @@ class PhotoCollageState extends State<PhotoCollage> {
   }
 
   Widget get _layout {
-    print("Rendering layout; initialized: $initialized; nChosen: $nChosen");
-    // print("frontTemplate: ${frontTemplate != null}");
     return Stack(
       fit: StackFit.expand,
       children: [

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -36,6 +36,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onSinglePhotoIsCollageChanged(bool? singlePhotoIsCollage) {
+    if (singlePhotoIsCollage != null) {
+      viewModel.updateSettings((settings) => settings.copyWith(singlePhotoIsCollage: singlePhotoIsCollage));
+    }
+  }
+
   void onTemplatesFolderChanged(String? templatesFolder) {
     if (templatesFolder != null) {
       viewModel.updateSettings((settings) => settings.copyWith(templatesFolder: templatesFolder));

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -13,6 +13,9 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   TextEditingController? _localFolderController;
   TextEditingController get localFolderSettingController => _localFolderController ??= TextEditingController(text: viewModel.localFolderSetting);
 
+  TextEditingController? _templatesFolderController;
+  TextEditingController get templatesFolderSettingController => _templatesFolderController ??= TextEditingController(text: viewModel.templatesFolderSetting);
+
   TextEditingController? _firefoxSendServerUrlController;
   TextEditingController get firefoxSendServerUrlController => _firefoxSendServerUrlController ??= TextEditingController(text: viewModel.firefoxSendServerUrlSetting);
 
@@ -30,6 +33,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
   void onCaptureDelaySecondsChanged(int? captureDelaySeconds) {
     if (captureDelaySeconds != null) {
       viewModel.updateSettings((settings) => settings.copyWith(captureDelaySeconds: captureDelaySeconds));
+    }
+  }
+
+  void onTemplatesFolderChanged(String? templatesFolder) {
+    if (templatesFolder != null) {
+      viewModel.updateSettings((settings) => settings.copyWith(templatesFolder: templatesFolder));
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -1,3 +1,4 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_rust_bridge_example/models/settings.dart';
@@ -127,10 +128,11 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
               value: () => viewModel.captureMethodSetting,
               onChanged: controller.onCaptureMethodChanged,
             ),
-            _getTextInput(
+            _getFolderPickerCard(
               icon: FluentIcons.folder,
               title: "Capture location",
               subtitle: "Location to look for captured images",
+              dialogTitle: "Select location to look for captured images",
               controller: controller.captureLocationController,
               onChanged: controller.onCaptureLocationChanged,
             ),
@@ -207,10 +209,11 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
         FluentSettingsBlock(
           title: "Local",
           settings: [
-            _getTextInput(
+            _getFolderPickerCard(
               icon: FluentIcons.fabric_picture_library,
               title: "Local photo storage location",
               subtitle: "Location where the output images will be stored",
+              dialogTitle: "Select local output storage location",
               controller: controller.localFolderSettingController,
               onChanged: controller.onLocalFolderChanged,
             ),

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -81,8 +81,21 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
               onChanged: controller.onCaptureDelaySecondsChanged,
             ),
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              padding: const EdgeInsets.only(top: 8.0),
               child: Text("Hit Ctrl+F or Alt+Enter to toggle fullscreen mode."),
+            ),
+          ],
+        ),
+        FluentSettingsBlock(
+          title: "Creative",
+          settings: [
+            _getFolderPickerCard(
+              icon: FluentIcons.fabric_report_library,
+              title: "Collage background templates location",
+              subtitle: "Location to look for template files",
+              dialogTitle: "Select templates location",
+              controller: controller.templatesFolderSettingController,
+              onChanged: controller.onTemplatesFolderChanged,
             ),
           ],
         ),

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -97,6 +97,13 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
               controller: controller.templatesFolderSettingController,
               onChanged: controller.onTemplatesFolderChanged,
             ),
+            _getBooleanInput(
+              icon: FluentIcons.picture_center,
+              title: "Treat single photo as collage",
+              subtitle: "If enabled, a single picture will be processed as if it were a collage with 1 photo selected. Else the photo will be used unaltered.",
+              value: () => viewModel.singlePhotoIsCollageSetting,
+              onChanged: controller.onSinglePhotoIsCollageChanged,
+            ),
           ],
         ),
       ],

--- a/lib/views/settings_screen/settings_screen_view.helpers.dart
+++ b/lib/views/settings_screen/settings_screen_view.helpers.dart
@@ -74,6 +74,26 @@ FluentSettingCard _getTextInput({
   );
 }
 
+FluentSettingCard _getBooleanInput({
+  required IconData icon,
+  required String title,
+  required String subtitle,
+  required GetValueCallback<bool> value,
+  required ValueChanged<bool> onChanged,
+}) {
+  return FluentSettingCard(
+    icon: icon,
+    title: title,
+    subtitle: subtitle,
+    child: Observer(builder: (_) {
+      return ToggleSwitch(
+        checked: value(),
+        onChanged: onChanged,
+      );
+    }),
+  );
+}
+
 FluentSettingCard _getFolderPickerCard<TValue>({
   required IconData icon,
   required String title,

--- a/lib/views/settings_screen/settings_screen_view.helpers.dart
+++ b/lib/views/settings_screen/settings_screen_view.helpers.dart
@@ -52,8 +52,6 @@ FluentSettingCard _getInput<T extends num>({
   );
 }
 
-
-
 FluentSettingCard _getTextInput({
   required IconData icon,
   required String title,
@@ -72,6 +70,46 @@ FluentSettingCard _getTextInput({
         onChanged: onChanged,
         // Todo: See if there is a better way to fire onChanged instead of every button press.
       ),
+    ),
+  );
+}
+
+FluentSettingCard _getFolderPickerCard<TValue>({
+  required IconData icon,
+  required String title,
+  required String subtitle,
+  String? dialogTitle,
+  required TextEditingController controller,
+  required ValueChanged<String?> onChanged,
+}) {
+  return FluentSettingCard(
+    icon: icon,
+    title: title,
+    subtitle: subtitle,
+    child: Row(
+      children: [
+        IconButton(
+          icon: const Icon(FluentIcons.folder, size: 24.0),
+          onPressed: () async {
+            String? selectedDirectory = await FilePicker.platform.getDirectoryPath(dialogTitle: dialogTitle, initialDirectory: controller.text);
+            if (selectedDirectory == null) return;
+            controller.text = selectedDirectory;
+            onChanged(selectedDirectory);
+          },
+        ),
+        SizedBox(width: 10),
+        ConstrainedBox(
+          constraints: BoxConstraints(minWidth: 150),
+          child: SizedBox(
+            width: 250,
+            child: TextBox(
+              enabled: false,
+              controller: controller,
+              onChanged: onChanged,
+            ),
+          ),
+        ),
+      ],
     ),
   );
 }

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -32,8 +32,6 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
 
   void setPrinterList() async {
     final printers = await Printing.listPrinters();
-    print("Getting printers:");
-    print(printers);
     printerOptions.clear();
     for (var printer in printers) {
       final icon = printer.isAvailable ? FluentIcons.plug_connected : FluentIcons.plug_disconnected;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -62,6 +62,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   // Current values
 
   int get captureDelaySecondsSetting => SettingsManagerBase.instance.settings.captureDelaySeconds;
+  String get templatesFolderSetting => SettingsManagerBase.instance.settings.templatesFolder;
   LiveViewMethod get liveViewMethodSetting => SettingsManagerBase.instance.settings.hardware.liveViewMethod;
   String get liveViewWebcamId => SettingsManagerBase.instance.settings.hardware.liveViewWebcamId;
   Flip get liveViewFlipImage => SettingsManagerBase.instance.settings.hardware.liveViewFlipImage;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -62,6 +62,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   // Current values
 
   int get captureDelaySecondsSetting => SettingsManagerBase.instance.settings.captureDelaySeconds;
+  bool get singlePhotoIsCollageSetting => SettingsManagerBase.instance.settings.singlePhotoIsCollage;
   String get templatesFolderSetting => SettingsManagerBase.instance.settings.templatesFolder;
   LiveViewMethod get liveViewMethodSetting => SettingsManagerBase.instance.settings.hardware.liveViewMethod;
   String get liveViewWebcamId => SettingsManagerBase.instance.settings.hardware.liveViewWebcamId;

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -24,6 +24,16 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
   void onClickNext() {
     router.push("/");
   }
+  
+  void onClickPrev() {
+    print("clicking prev");
+    if (PhotosManagerBase.instance.captureMode == CaptureMode.single) {
+      PhotosManagerBase.instance.reset(advance: false);
+      router.push('/capture');
+    } else {
+      router.pop();
+    }
+  }
 
   String get ffSendUrl => SettingsManagerBase.instance.settings.output.firefoxSendServerUrl;
 

--- a/lib/views/share_screen/share_screen_view.dart
+++ b/lib/views/share_screen/share_screen_view.dart
@@ -61,17 +61,29 @@ class ShareScreenView extends ScreenViewBase<ShareScreenViewModel, ShareScreenCo
         ),
         Expanded(
           flex: 3,
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: GestureDetector(
-              // Next button
-              onTap: controller.onClickNext,
-              behavior: HitTestBehavior.translucent,
-              child: AutoSizeText(
-                "→ ",
-                style: theme.titleStyle,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              GestureDetector(
+                // Next button
+                onTap: controller.onClickPrev,
+                behavior: HitTestBehavior.translucent,
+                child: AutoSizeText(
+                  " ↺ ${viewModel.backText}",
+                  style: theme.subTitleStyle,
+                ),
               ),
-            ),
+              GestureDetector(
+                // Next button
+                onTap: controller.onClickNext,
+                behavior: HitTestBehavior.translucent,
+                child: AutoSizeText(
+                  "→ ",
+                  style: theme.titleStyle,
+                ),
+              ),
+            ],
           ),
         ),
         Flexible(

--- a/lib/views/share_screen/share_screen_view_model.dart
+++ b/lib/views/share_screen/share_screen_view_model.dart
@@ -37,6 +37,9 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
   @observable
   String qrUrl = "";
 
+  CaptureMode get captureMode => PhotosManagerBase.instance.captureMode;
+  String get backText => captureMode == CaptureMode.single ? "Retake" : "Change";
+
   /// Global key for controlling the slider widget.
   GlobalKey<SliderWidgetState> sliderKey = GlobalKey<SliderWidgetState>();
 

--- a/lib/views/start_screen/start_screen_controller.dart
+++ b/lib/views/start_screen/start_screen_controller.dart
@@ -16,10 +16,6 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> {
 
   void onPressedContinue() {
     router.push(ChooseCaptureModeScreen.defaultRoute);
-    // Remove images in memory
-    // Fixme: maybe somewhere else is nicer, but for now it's here.
-    PhotosManagerBase.instance.photos.clear();
-    PhotosManagerBase.instance.chosen.clear();
   }
 
 }

--- a/lib/views/start_screen/start_screen_view_model.dart
+++ b/lib/views/start_screen/start_screen_view_model.dart
@@ -9,6 +9,8 @@ class StartScreenViewModel = StartScreenViewModelBase with _$StartScreenViewMode
 abstract class StartScreenViewModelBase extends ScreenViewModelBase with Store {
 
   StartScreenViewModelBase({required super.contextAccessor}) {
+    // Remove images in memory
+    // Fixme: maybe somewhere else is nicer, but for now it's here.
     PhotosManagerBase.instance.reset();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: dcde5ad1a0cebcf3715ea3f24d0db1888bf77027a26c77d7779e8ef63b8ade62
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.9"
   fixnum:
     dependency: transitive
     description:
@@ -320,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.6+5"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: c224ac897bed083dabf11f238dd11a239809b446740be0c2044608c50029ffdf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.9"
   flutter_rust_bridge:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ dependencies:
   # Misc
   meta: 1.8.0
   toml: 0.14.0
+  file_picker: ^5.2.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* A directory picker ([using this](https://pub.dev/packages/file_picker)) has been added to the settings screen.
* A template system has been introduced to style processed pictures/collages
  * Fore- and background images live in the template directory, selectable in settings.
  * A fore- or background image can either be general, or specific to the number of selected images
  * Naming system is `{front/back}-template{-#}.{png/jpg}`.
* The collage maker now displays the order of selection for photos instead of a ✔️
* The layout of the collages is slightly improved
  * The display of the logo is now a boolean (that is not used yet)  
    This could later be used to set a logo without creating front-/background templates.
* Image output is now written enumerated, the last number in the output dir is automatically detected
* Single images can now be processed as a "1-picture collage" with a setting (default **on**)
* A retake/change back-button has been added to the share screen.

The biggest issue still remaining with photo processing is the orientation of the image.