### PR TITLE
Collage output and UX enhancements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,8 @@ class _AppState extends State<App> {
   @override
   void initState() {
     _initHotKeys();
+    // Check if the window is fullscreen from the start.
+    windowManager.isFullScreen().then((value) => _isFullScreen = value);
     super.initState();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:momento_booth/extensions/build_context_extension.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
@@ -53,11 +55,16 @@ class _AppState extends State<App> {
   bool _settingsOpen = false;
   bool _isFullScreen = false;
 
+  static final returnHomeTimeout = Duration(seconds: 45);
+  late Timer _returnHome;
+
   @override
   void initState() {
     _initHotKeys();
     // Check if the window is fullscreen from the start.
     windowManager.isFullScreen().then((value) => _isFullScreen = value);
+    _returnHome = Timer(returnHomeTimeout, _goHome);
+    _router.addListener(() { onActivity(null); });
     super.initState();
   }
 
@@ -100,6 +107,18 @@ class _AppState extends State<App> {
     );
   }
 
+  void _goHome() {
+    print("No activity in $returnHomeTimeout, returning to homescreen");
+    _router.push('/');
+  }
+
+  /// Method that is fired when a user does any kind of touch or the route changes.
+  /// This resets the return home timer.
+  void onActivity(PointerEvent? event) {
+    _returnHome.cancel();
+    _returnHome = Timer(returnHomeTimeout, _goHome);
+  }
+
   @override
   Widget build(BuildContext context) {
     return MomentoBoothTheme(
@@ -125,7 +144,11 @@ class _AppState extends State<App> {
         return LiveViewBackground(
           child: Stack(
             children: [
-              child!,
+              Listener(
+                behavior: HitTestBehavior.translucent,
+                onPointerDown: onActivity,
+                child: child!,
+              ),
               _settingsOpen ? _settingsScreen : const SizedBox(),
             ],
           ),

--- a/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
@@ -28,7 +28,11 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   String get outputFolder => SettingsManagerBase.instance.settings.output.localFolder;
 
+  int imageProcessing = 0;
+
   void captureCollage() async {
+    viewModel.readyToContinue = false;
+    imageProcessing++; // To deal with concurrent processes
     final stopwatch = Stopwatch()..start();
     final pixelRatio = SettingsManagerBase.instance.settings.output.resolutionMultiplier;
     final format = SettingsManagerBase.instance.settings.output.exportFormat;
@@ -38,10 +42,12 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
     print("Written collage image to output image memory");
     
     PhotosManagerBase.instance.writeOutput();
+    imageProcessing--;
+    viewModel.readyToContinue = imageProcessing == 0;
   }
 
   void onContinueTap() {
-    // Todo: a whole lot of stuff
+    if (!viewModel.readyToContinue) return;
     router.push("/share");
   }
 

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -141,7 +141,7 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
       builder: (context) => AnimatedRotation(
         duration: Duration(milliseconds: 300),
         curve: Curves.easeInOut,
-        turns: -0.25 * viewModel.rotation,
+        turns: -0.25 * viewModel.rotation, // could also use controller.collageKey.currentState!.rotation
         child: Container(
           decoration: BoxDecoration(
             color: Color.fromARGB(255, 255, 255, 255),

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -42,9 +42,15 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
           padding: EdgeInsets.symmetric(horizontal: 35, vertical: 10),
           child: Align(
             alignment: Alignment.bottomRight,
-            child: GestureDetector(
-              onTap: controller.onContinueTap,
-              child: AutoSizeText("Continue  →", style: theme.subTitleStyle, maxLines: 1,)
+            child: Observer(
+              builder: (context) => AnimatedOpacity(
+                duration: viewModel.opacityDuraction,
+                opacity: viewModel.readyToContinue ? 1 : 0.5,
+                child: GestureDetector(
+                  onTap: controller.onContinueTap,
+                  child: AutoSizeText("Continue  →", style: theme.subTitleStyle, maxLines: 1,)
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
@@ -15,5 +15,10 @@ abstract class CollageMakerScreenViewModelBase extends ScreenViewModelBase with 
   int get numSelected => PhotosManagerBase.instance.chosen.length;
 
   int get rotation => [0, 1, 4].contains(numSelected) ? 1 : 0;
+  
+  @observable
+  bool readyToContinue = false;
+
+  final Duration opacityDuraction = Duration(milliseconds: 300);
 
 }

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -69,6 +69,7 @@ class PhotoCollageState extends State<PhotoCollage> {
   ObservableList<Uint8List> get photos => PhotosManagerBase.instance.photos;
   Iterable<Uint8List> get chosenPhotos => PhotosManagerBase.instance.chosenPhotos;
   int get nChosen => PhotosManagerBase.instance.chosen.length;
+  int get rotation => [0, 1, 4].contains(nChosen) ? 1 : 0;
 
   String get templatesFolder => SettingsManagerBase.instance.settings.templatesFolder;
 
@@ -285,7 +286,8 @@ class PhotoCollageState extends State<PhotoCollage> {
     //final dartImage = img.Image.fromBytes(width: image.width, height: image.height, bytes: byteData!.buffer, numChannels: 4, order: img.ChannelOrder.rgba);
     //final jpg = img.encodeJpg(dartImage, quality: jpgQuality);
     final rawImage = RawImage(format: RawImageFormat.Rgba, data: byteData!.buffer.asUint8List(), width: image.width, height: image.height);
-    final jpg = await rustLibraryApi.jpegEncode(rawImage: rawImage, quality: jpgQuality, operationsBeforeEncoding: []);
+    final List<ImageOperation> operationsBeforeEncoding = rotation == 1 ? [ImageOperation.rotate(Rotation.Rotate270)] : [];
+    final jpg = await rustLibraryApi.jpegEncode(rawImage: rawImage, quality: jpgQuality, operationsBeforeEncoding: operationsBeforeEncoding);
     return jpg;
   }
 

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -116,12 +116,15 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
       })
     );
 
-    await Printing.directPrintPdf(
+    bool success = await Printing.directPrintPdf(
         printer: selected,
         name: "MomentoBooth image",
         format: pageFormat,
         onLayout: (PdfPageFormat pageFormat) => doc.save()
     );
+
+    viewModel.printText = success ? "Printing..." : "Print canceled";
+    Future.delayed(Duration(seconds: 2), () => viewModel.printText = "Print");
   }
 
 }

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -93,18 +93,26 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
     }
 
     // Get photo and print it.
-    final photoToPrint = PhotosManagerBase.instance.photos.first;
+    final photoToPrint = PhotosManagerBase.instance.outputImage!;
     final image = pw.MemoryImage(photoToPrint);
     const pageFormat = PdfPageFormat(100.0 * PdfPageFormat.mm, 150.0 * PdfPageFormat.mm);
+    const fit = pw.BoxFit.contain;
+
+    // Check if photo should be rotated
+    // Do not assume any prior knowledge about the image.
+    final bool rotate = image.width! > image.height!;
+    late final pw.Image imageWidget;
+    if (rotate) {
+      imageWidget = pw.Image(image, fit: fit, height: pageFormat.width, width: pageFormat.height);
+    } else {
+      imageWidget = pw.Image(image, fit: fit, height: pageFormat.height, width: pageFormat.width);
+    }
 
     final doc = pw.Document(title: "MomentoBooth image");
     doc.addPage(pw.Page(
       pageFormat: pageFormat,
       build: (pw.Context context) {
-        return pw.Transform.rotateBox(
-          angle: 0.5*pi,
-          child: pw.Image(image, fit: pw.BoxFit.contain, height: pageFormat.width, width: pageFormat.height),
-        );
+        return rotate ? pw.Transform.rotateBox(angle: 0.5*pi, child: imageWidget,) : imageWidget;
       })
     );
 

--- a/lib/views/share_screen/share_screen_view.dart
+++ b/lib/views/share_screen/share_screen_view.dart
@@ -172,9 +172,11 @@ class ShareScreenView extends ScreenViewBase<ShareScreenViewModel, ShareScreenCo
             // Print button
             onTap: controller.onClickPrint,
             behavior: HitTestBehavior.translucent,
-            child: AutoSizeText(
-              "Print",
-              style: theme.titleStyle,
+            child: Observer(
+              builder: (context) => AutoSizeText(
+                viewModel.printText,
+                style: theme.titleStyle,
+              ),
             ),
           ),
         ),

--- a/lib/views/share_screen/share_screen_view_model.dart
+++ b/lib/views/share_screen/share_screen_view_model.dart
@@ -34,6 +34,9 @@ abstract class ShareScreenViewModelBase extends ScreenViewModelBase with Store {
   String qrText = "Get QR";
 
   @observable
+  String printText = "Print";
+
+  @observable
   UploadState uploadState = UploadState.notStarted;
 
   @observable

--- a/lib/views/start_screen/start_screen_view.dart
+++ b/lib/views/start_screen/start_screen_view.dart
@@ -18,6 +18,7 @@ class StartScreenView extends ScreenViewBase<StartScreenViewModel, StartScreenCo
   Widget get body {
     return GestureDetector(
       onTap: controller.onPressedContinue,
+      behavior: HitTestBehavior.opaque,
       child: _foregroundElements,
     );
   }


### PR DESCRIPTION
* The rotation functionality of #71 has been used to properly rotate the collage output
  * Possible image rotation is handled in the share print function as well
* Visual feedback when having pressed the print button on the share screen.
* Continue button on collage maker screen can now not be pressed until the rendering is finished.
* Start screen had a little bug where touch was only recognized when touching one of the visible UI elements. This has been fixed.
* The app now automatically navigates home after 45 seconds of inactivity.
  * This could be a setting, maybe convenient for during development.