### PR TITLE
Fix memory leaking from old screen state

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,7 +109,7 @@ class _AppState extends State<App> {
 
   void _goHome() {
     print("No activity in $returnHomeTimeout, returning to homescreen");
-    _router.push(StartScreen.defaultRoute);
+    _router.go(StartScreen.defaultRoute);
   }
 
   /// Method that is fired when a user does any kind of touch or the route changes.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,7 +109,7 @@ class _AppState extends State<App> {
 
   void _goHome() {
     print("No activity in $returnHomeTimeout, returning to homescreen");
-    _router.push('/');
+    _router.push(StartScreen.defaultRoute);
   }
 
   /// Method that is fired when a user does any kind of touch or the route changes.
@@ -133,8 +133,7 @@ class _AppState extends State<App> {
 
   Widget _getWidgetsApp(BuildContext context) {
     return WidgetsApp.router(
-      routeInformationParser: _router.routeInformationParser,
-      routerDelegate: _router.routerDelegate,
+      routerConfig: _router,
       color: context.theme.primaryColor,
       localizationsDelegates: [
         FluentLocalizations.delegate,

--- a/lib/main.routes.dart
+++ b/lib/main.routes.dart
@@ -44,7 +44,7 @@ GoRoute _multiCaptureRoute = GoRoute(
   path: MultiCaptureScreen.defaultRoute,
   pageBuilder: (context, state) {
     return FadeTransitionPage(
-      key: state.pageKey,
+      key: UniqueKey(),
       child: MultiCaptureScreen(),
     );
   },

--- a/lib/views/base/build_context_abstractor.dart
+++ b/lib/views/base/build_context_abstractor.dart
@@ -12,4 +12,7 @@ mixin BuildContextAbstractor {
   MomentoBoothThemeData get theme => _context.theme;
   GoRouter get router => _context.router;
 
+  NavigatorState get navigator => _context.navigator;
+  NavigatorState get rootNavigator => _context.rootNavigator;
+
 }

--- a/lib/views/base/fade_transition_page.dart
+++ b/lib/views/base/fade_transition_page.dart
@@ -3,20 +3,24 @@ import 'package:go_router/go_router.dart';
 
 class FadeTransitionPage extends CustomTransitionPage<void> {
 
+  static final CurveTween _curveTween = CurveTween(curve: Curves.easeInOutCubicEmphasized);
+
   /// Creates a [FadeTransitionPage].
   FadeTransitionPage({
     required LocalKey super.key,
     required super.child,
   }) : super(
+          transitionDuration: const Duration(milliseconds: 500),
+          reverseTransitionDuration: const Duration(milliseconds: 500),
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             return FadeTransition(
-              opacity: Tween<double>(begin: 0.0, end: 1.0).animate(animation),
+              opacity: Tween<double>(begin: 0.0, end: 1.0).animate(animation.drive(_curveTween)),
               child: ScaleTransition(
-                scale: Tween<double>(begin: 0.95, end: 1.0).animate(animation),
+                scale: Tween<double>(begin: 0.95, end: 1.0).animate(animation.drive(_curveTween)),
                 child: FadeTransition(
-                  opacity: Tween<double>(begin: 1.0, end: 0.0).animate(secondaryAnimation),
+                  opacity: Tween<double>(begin: 1.0, end: 0.0).animate(secondaryAnimation.drive(_curveTween)),
                   child: ScaleTransition(
-                    scale: Tween<double>(begin: 1.0, end: 1.3).animate(secondaryAnimation),
+                    scale: Tween<double>(begin: 1.0, end: 1.3).animate(secondaryAnimation.drive(_curveTween)),
                     child: child,
                   ),
                 ),

--- a/lib/views/base/fade_transition_page.dart
+++ b/lib/views/base/fade_transition_page.dart
@@ -3,8 +3,6 @@ import 'package:go_router/go_router.dart';
 
 class FadeTransitionPage extends CustomTransitionPage<void> {
 
-  static final CurveTween _curveTween = CurveTween(curve: Curves.easeIn);
-
   /// Creates a [FadeTransitionPage].
   FadeTransitionPage({
     required LocalKey super.key,
@@ -12,8 +10,17 @@ class FadeTransitionPage extends CustomTransitionPage<void> {
   }) : super(
           transitionsBuilder: (context, animation, secondaryAnimation, child) {
             return FadeTransition(
-              opacity: animation.drive(_curveTween),
-              child: child,
+              opacity: Tween<double>(begin: 0.0, end: 1.0).animate(animation),
+              child: ScaleTransition(
+                scale: Tween<double>(begin: 0.95, end: 1.0).animate(animation),
+                child: FadeTransition(
+                  opacity: Tween<double>(begin: 1.0, end: 0.0).animate(secondaryAnimation),
+                  child: ScaleTransition(
+                    scale: Tween<double>(begin: 1.0, end: 1.3).animate(secondaryAnimation),
+                    child: child,
+                  ),
+                ),
+              ),
             );
           },
         );

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -11,6 +11,7 @@ import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/views/share_screen/share_screen.dart';
 
 part 'capture_screen_view_model.g.dart';
 
@@ -100,7 +101,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
 
   void navigateAfterCapture() {
     if (!flashComplete || !captureComplete) { return; }
-    router.push("/share");
+    router.push(ShareScreen.defaultRoute);
   }
 
 }

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -101,7 +101,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
 
   void navigateAfterCapture() {
     if (!flashComplete || !captureComplete) { return; }
-    router.push(ShareScreen.defaultRoute);
+    router.go(ShareScreen.defaultRoute);
   }
 
 }

--- a/lib/views/choose_capture_mode_screen/choose_capture_mode_screen_controller.dart
+++ b/lib/views/choose_capture_mode_screen/choose_capture_mode_screen_controller.dart
@@ -1,6 +1,8 @@
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
+import 'package:momento_booth/views/capture_screen/capture_screen.dart';
 import 'package:momento_booth/views/choose_capture_mode_screen/choose_capture_mode_screen_view_model.dart';
+import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen.dart';
 
 class ChooseCaptureModeScreenController extends ScreenControllerBase<ChooseCaptureModeScreenViewModel> {
 
@@ -15,12 +17,12 @@ class ChooseCaptureModeScreenController extends ScreenControllerBase<ChooseCaptu
 
   void onClickOnSinglePhoto() {
     PhotosManagerBase.instance.captureMode = CaptureMode.single;
-    router.push("/capture");
+    router.push(CaptureScreen.defaultRoute);
   }
 
   void onClickOnPhotoCollage() {
     PhotosManagerBase.instance.captureMode = CaptureMode.collage;
-    router.push("/multi-capture");
+    router.push(MultiCaptureScreen.defaultRoute);
   }
 
 }

--- a/lib/views/choose_capture_mode_screen/choose_capture_mode_screen_controller.dart
+++ b/lib/views/choose_capture_mode_screen/choose_capture_mode_screen_controller.dart
@@ -17,12 +17,12 @@ class ChooseCaptureModeScreenController extends ScreenControllerBase<ChooseCaptu
 
   void onClickOnSinglePhoto() {
     PhotosManagerBase.instance.captureMode = CaptureMode.single;
-    router.push(CaptureScreen.defaultRoute);
+    router.go(CaptureScreen.defaultRoute);
   }
 
   void onClickOnPhotoCollage() {
     PhotosManagerBase.instance.captureMode = CaptureMode.collage;
-    router.push(MultiCaptureScreen.defaultRoute);
+    router.go(MultiCaptureScreen.defaultRoute);
   }
 
 }

--- a/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
@@ -58,7 +58,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   void onContinueTap() {
     if (!viewModel.readyToContinue) return;
-    router.push(ShareScreen.defaultRoute);
+    router.go(ShareScreen.defaultRoute);
   }
 
 }

--- a/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_controller.dart
@@ -4,6 +4,7 @@ import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen_view_model.dart';
 import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
+import 'package:momento_booth/views/share_screen/share_screen.dart';
 
 class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScreenViewModel> {
 
@@ -57,7 +58,7 @@ class CollageMakerScreenController extends ScreenControllerBase<CollageMakerScre
 
   void onContinueTap() {
     if (!viewModel.readyToContinue) return;
-    router.push("/share");
+    router.push(ShareScreen.defaultRoute);
   }
 
 }

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -82,7 +82,7 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
     if (PhotosManagerBase.instance.photos.length >= maxPhotos) {
       router.go(CollageMakerScreen.defaultRoute);
     } else {
-      router.go(MultiCaptureScreen.defaultRoute);
+      router.go("${MultiCaptureScreen.defaultRoute}?n=${PhotosManagerBase.instance.photos.length}");
     }
   }
 

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -80,9 +80,9 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
   void navigateAfterCapture() {
     if (!flashComplete || !captureComplete) { return; }
     if (PhotosManagerBase.instance.photos.length >= maxPhotos) {
-      router.push(CollageMakerScreen.defaultRoute);
+      router.go(CollageMakerScreen.defaultRoute);
     } else {
-      router.push(MultiCaptureScreen.defaultRoute);
+      router.go(MultiCaptureScreen.defaultRoute);
     }
   }
 

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -7,6 +7,8 @@ import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:momento_booth/models/settings.dart';
 import 'package:mobx/mobx.dart';
+import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen.dart';
+import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen.dart';
 
 part 'multi_capture_screen_view_model.g.dart';
 
@@ -78,9 +80,9 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
   void navigateAfterCapture() {
     if (!flashComplete || !captureComplete) { return; }
     if (PhotosManagerBase.instance.photos.length >= maxPhotos) {
-      router.push("/collage-maker");
+      router.push(CollageMakerScreen.defaultRoute);
     } else {
-      router.push("/multi-capture");
+      router.push(MultiCaptureScreen.defaultRoute);
     }
   }
 

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -49,24 +49,24 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
           PaneItem(
             icon: Icon(FluentIcons.settings),
             title: Text("General"),
-            body: _generalSettings,
+            body: Builder(builder: (_) => _generalSettings),
           ),
           PaneItem(
             icon: Icon(FluentIcons.devices4),
             title: Text("Hardware"),
-            body: _hardwareSettings,
+            body: Builder(builder: (_) => _hardwareSettings),
           ),
           PaneItem(
             icon: Icon(FluentIcons.send),
             title: Text("Output"),
-            body: _outputSettings,
+            body: Builder(builder: (_) => _outputSettings),
           ),
         ],
       ),
     );
   }
 
-  Widget get _generalSettings {
+  Widget get _generalSettings { 
     return FluentSettingsPage(
       title: "General",
       blocks: [

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -25,44 +25,40 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
       data: FluentThemeData(),
       child: Builder(
         builder: (context) {
-          return Observer(builder: (_) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Expanded(child: _navigationView),
-              ],
-            );
-          });
+          return _navigationView;
         },
       ),
     );
   }
 
   Widget get _navigationView {
-    return NavigationView(
-      pane: NavigationPane(
-        selected: viewModel.paneIndex,
-        onChanged: controller.onNavigationPaneIndexChanged,
-        items: [
-          PaneItemSeparator(color: Colors.transparent),
-          PaneItem(
-            icon: Icon(FluentIcons.settings),
-            title: Text("General"),
-            body: Builder(builder: (_) => _generalSettings),
+    return Observer(
+      builder: (context) {
+        return NavigationView(
+          pane: NavigationPane(
+            selected: viewModel.paneIndex,
+            onChanged: controller.onNavigationPaneIndexChanged,
+            items: [
+              PaneItemSeparator(color: Colors.transparent),
+              PaneItem(
+                icon: Icon(FluentIcons.settings),
+                title: Text("General"),
+                body: Builder(builder: (_) => _generalSettings),
+              ),
+              PaneItem(
+                icon: Icon(FluentIcons.devices4),
+                title: Text("Hardware"),
+                body: Builder(builder: (_) => _hardwareSettings),
+              ),
+              PaneItem(
+                icon: Icon(FluentIcons.send),
+                title: Text("Output"),
+                body: Builder(builder: (_) => _outputSettings),
+              ),
+            ],
           ),
-          PaneItem(
-            icon: Icon(FluentIcons.devices4),
-            title: Text("Hardware"),
-            body: Builder(builder: (_) => _hardwareSettings),
-          ),
-          PaneItem(
-            icon: Icon(FluentIcons.send),
-            title: Text("Output"),
-            body: Builder(builder: (_) => _outputSettings),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -24,14 +24,14 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
   });
 
   void onClickNext() {
-    router.push(StartScreen.defaultRoute);
+    router.go(StartScreen.defaultRoute);
   }
   
   void onClickPrev() {
     print("clicking prev");
     if (PhotosManagerBase.instance.captureMode == CaptureMode.single) {
       PhotosManagerBase.instance.reset(advance: false);
-      router.push(CaptureScreen.defaultRoute);
+      router.go(CaptureScreen.defaultRoute);
     } else {
       router.pop();
     }

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -7,6 +7,7 @@ import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/capture_screen/capture_screen.dart';
+import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen.dart';
 import 'package:momento_booth/views/share_screen/share_screen_view_model.dart';
 import 'package:momento_booth/views/start_screen/start_screen.dart';
 import 'package:path_provider/path_provider.dart';
@@ -33,7 +34,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
       PhotosManagerBase.instance.reset(advance: false);
       router.go(CaptureScreen.defaultRoute);
     } else {
-      router.pop();
+      router.go(CollageMakerScreen.defaultRoute);
     }
   }
 

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -6,7 +6,9 @@ import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
+import 'package:momento_booth/views/capture_screen/capture_screen.dart';
 import 'package:momento_booth/views/share_screen/share_screen_view_model.dart';
+import 'package:momento_booth/views/start_screen/start_screen.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
@@ -22,14 +24,14 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
   });
 
   void onClickNext() {
-    router.push("/");
+    router.push(StartScreen.defaultRoute);
   }
   
   void onClickPrev() {
     print("clicking prev");
     if (PhotosManagerBase.instance.captureMode == CaptureMode.single) {
       PhotosManagerBase.instance.reset(advance: false);
-      router.push('/capture');
+      router.push(CaptureScreen.defaultRoute);
     } else {
       router.pop();
     }

--- a/lib/views/start_screen/start_screen_controller.dart
+++ b/lib/views/start_screen/start_screen_controller.dart
@@ -15,7 +15,7 @@ class StartScreenController extends ScreenControllerBase<StartScreenViewModel> {
   // User interaction methods
 
   void onPressedContinue() {
-    router.push(ChooseCaptureModeScreen.defaultRoute);
+    router.go(ChooseCaptureModeScreen.defaultRoute);
   }
 
 }


### PR DESCRIPTION
This PR:
- Fixes the memory leaking from old screens kept alive due to using `push`/`pop` based navigation
- Adds nice animations to animate between screens
- Fixes the log from the native library not working after hot restart
- Wraps the settings panes with a `Builder` to make sure they don't get rebuild when not needed (fixes state loss while changing settings)