### PR TITLE
Fix printing

### DIFF
--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -61,6 +61,13 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
     required CaptureMethod captureMethod,
     required String captureLocation,
     required String printerName,
+    required double pageHeight,
+    required double pageWidth,
+    required bool usePrinterSettings,
+    required double printerMarginTop,
+    required double printerMarginRight,
+    required double printerMarginBottom,
+    required double printerMarginLeft,
   }) = _HardwareSettings;
 
   factory HardwareSettings.withDefaults() {
@@ -71,6 +78,13 @@ class HardwareSettings with _$HardwareSettings implements TomlEncodableValue {
       captureMethod: CaptureMethod.liveViewSource,
       captureLocation: _getHome(),
       printerName: "",
+      pageHeight: 148,
+      pageWidth: 100,
+      usePrinterSettings: true,
+      printerMarginTop: 0,
+      printerMarginRight: 0,
+      printerMarginBottom: 0,
+      printerMarginLeft: 0,
     );
   }
 

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -90,6 +90,48 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onPageHeightChanged(double? pageHeight) {
+    if (pageHeight != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(pageHeight: pageHeight));
+    }
+  }
+
+  void onPageWidthChanged(double? pageWidth) {
+    if (pageWidth != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(pageHeight: pageWidth));
+    }
+  }
+
+  void onUsePrinterSettingsChanged(bool? usePrinterSettings) {
+    if (usePrinterSettings != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(usePrinterSettings: usePrinterSettings));
+    }
+  }
+
+  void onPrinterMarginTopChanged(double? marginTop) {
+    if (marginTop != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(printerMarginTop: marginTop));
+    }
+  }
+
+  void onPrinterMarginRightChanged(double? marginRight) {
+    if (marginRight != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(printerMarginRight: marginRight));
+    }
+  }
+
+  void onPrinterMarginBottomChanged(double? marginBottom) {
+    if (marginBottom != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(printerMarginBottom: marginBottom));
+    }
+  }
+
+  void onPrinterMarginLeftChanged(double? marginLeft) {
+    if (marginLeft != null) {
+      viewModel.updateSettings((settings) => settings.copyWith.hardware(printerMarginLeft: marginLeft));
+    }
+  }
+
   void onLocalFolderChanged(String? localFolder) {
     if (localFolder != null) {
       viewModel.updateSettings((settings) => settings.copyWith.output(localFolder: localFolder));

--- a/lib/views/settings_screen/settings_screen_view.dart
+++ b/lib/views/settings_screen/settings_screen_view.dart
@@ -165,9 +165,90 @@ class SettingsScreenView extends ScreenViewBase<SettingsScreenViewModel, Setting
           title: "Printing",
           settings: [
             _printerCard,
+            _getInput(
+              icon: FluentIcons.page,
+              title: "Page height",
+              subtitle: 'Page format height used for printing [mm]',
+              value: () => viewModel.pageHeightSetting,
+              onChanged: controller.onPageHeightChanged,
+              smallChange: 0.1,
+            ),
+            _getInput(
+              icon: FluentIcons.page,
+              title: "Page width",
+              subtitle: 'Page format width used for printing [mm]',
+              value: () => viewModel.pageWidthSetting,
+              onChanged: controller.onPageWidthChanged,
+              smallChange: 0.1,
+            ),
+            _printerMargins,
+            _getBooleanInput(
+              icon: FluentIcons.settings,
+              title: "usePrinterSettings for printing",
+              subtitle: "Control the usePrinterSettings property of the Flutter printing library.",
+              value: () => viewModel.usePrinterSettingsSetting,
+              onChanged: controller.onUsePrinterSettingsChanged,
+            ),
           ],
         ),
       ],
+    );
+  }
+
+  FluentSettingCard get _printerMargins {
+    const double numberWidth = 100;
+    const double padding = 10;
+    return FluentSettingCard(
+      icon: FluentIcons.page,
+      title: "Page margins used for printing",
+      subtitle: "Some printers cut off some part of the image. Use this to compensate.\nOrder: top, right, bottom, left [mm]",
+      child: Row(
+        children: [
+          SizedBox(
+            width: numberWidth,
+            child: Observer(builder: (_) {
+              return NumberBox<double>(
+                value: viewModel.printerMarginTopSetting,
+                onChanged: controller.onPrinterMarginTopChanged,
+                smallChange: 0.1,
+              );
+            }),
+          ),
+          SizedBox(width: padding,),
+          SizedBox(
+            width: numberWidth,
+            child: Observer(builder: (_) {
+              return NumberBox<double>(
+                value: viewModel.printerMarginRightSetting,
+                onChanged: controller.onPrinterMarginRightChanged,
+                smallChange: 0.1,
+              );
+            }),
+          ),
+          SizedBox(width: padding,),
+          SizedBox(
+            width: numberWidth,
+            child: Observer(builder: (_) {
+              return NumberBox<double>(
+                value: viewModel.printerMarginBottomSetting,
+                onChanged: controller.onPrinterMarginBottomChanged,
+                smallChange: 0.1,
+              );
+            }),
+          ),
+          SizedBox(width: padding,),
+          SizedBox(
+            width: numberWidth,
+            child: Observer(builder: (_) {
+              return NumberBox<double>(
+                value: viewModel.printerMarginLeftSetting,
+                onChanged: controller.onPrinterMarginLeftChanged,
+                smallChange: 0.1,
+              );
+            }),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -71,6 +71,13 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   CaptureMethod get captureMethodSetting => SettingsManagerBase.instance.settings.hardware.captureMethod;
   String get captureLocationSetting => SettingsManagerBase.instance.settings.hardware.captureLocation;
   String get printerSetting => SettingsManagerBase.instance.settings.hardware.printerName;
+  double get pageHeightSetting => SettingsManagerBase.instance.settings.hardware.pageHeight;
+  double get pageWidthSetting => SettingsManagerBase.instance.settings.hardware.pageWidth;
+  bool get usePrinterSettingsSetting => SettingsManagerBase.instance.settings.hardware.usePrinterSettings;
+  double get printerMarginTopSetting => SettingsManagerBase.instance.settings.hardware.printerMarginTop;
+  double get printerMarginRightSetting => SettingsManagerBase.instance.settings.hardware.printerMarginRight;
+  double get printerMarginBottomSetting => SettingsManagerBase.instance.settings.hardware.printerMarginBottom;
+  double get printerMarginLeftSetting => SettingsManagerBase.instance.settings.hardware.printerMarginLeft;
   String get localFolderSetting => SettingsManagerBase.instance.settings.output.localFolder;
   String get firefoxSendServerUrlSetting => SettingsManagerBase.instance.settings.output.firefoxSendServerUrl;
   ExportFormat get exportFormat => SettingsManagerBase.instance.settings.output.exportFormat;

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
+import 'package:momento_booth/models/settings.dart';
 import 'package:momento_booth/rust_bridge/library_bridge.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
 import 'package:momento_booth/views/capture_screen/capture_screen.dart';
@@ -100,8 +101,12 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
     final photoToPrint = PhotosManagerBase.instance.outputImage!;
     final image = pw.MemoryImage(photoToPrint);
     const mm = PdfPageFormat.mm;
-    const pageFormat = PdfPageFormat(100.0 * mm, 148.0 * mm,
-                                     marginBottom: 3.5 * mm, marginLeft: 2.5 * mm, marginRight: 2.5 * mm, marginTop: 2.0 * mm);
+    final settings = SettingsManagerBase.instance.settings.hardware;
+    final pageFormat = PdfPageFormat(settings.pageWidth * mm, settings.pageHeight * mm,
+                                     marginBottom: settings.printerMarginBottom * mm,
+                                     marginLeft: settings.printerMarginLeft * mm,
+                                     marginRight: settings.printerMarginRight * mm,
+                                     marginTop: settings.printerMarginTop * mm,);
     const fit = pw.BoxFit.contain;
 
     // Check if photo should be rotated
@@ -131,7 +136,7 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
         name: "MomentoBooth image",
         format: pageFormat,
         onLayout: (PdfPageFormat pageFormat) => pdfData,
-        usePrinterSettings: true,
+        usePrinterSettings: settings.usePrinterSettings,
     );
 
     Directory outputDir = Directory(SettingsManagerBase.instance.settings.output.localFolder);

--- a/lib/views/share_screen/share_screen_controller.dart
+++ b/lib/views/share_screen/share_screen_controller.dart
@@ -99,7 +99,9 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
     // Get photo and print it.
     final photoToPrint = PhotosManagerBase.instance.outputImage!;
     final image = pw.MemoryImage(photoToPrint);
-    const pageFormat = PdfPageFormat(100.0 * PdfPageFormat.mm, 148.0 * PdfPageFormat.mm);
+    const mm = PdfPageFormat.mm;
+    const pageFormat = PdfPageFormat(100.0 * mm, 148.0 * mm,
+                                     marginBottom: 3.5 * mm, marginLeft: 2.5 * mm, marginRight: 2.5 * mm, marginTop: 2.0 * mm);
     const fit = pw.BoxFit.contain;
 
     // Check if photo should be rotated
@@ -107,9 +109,9 @@ class ShareScreenController extends ScreenControllerBase<ShareScreenViewModel> {
     final bool rotate = image.width! > image.height!;
     late final pw.Image imageWidget;
     if (rotate) {
-      imageWidget = pw.Image(image, fit: fit, height: pageFormat.width, width: pageFormat.height);
+      imageWidget = pw.Image(image, fit: fit, height: pageFormat.availableWidth, width: pageFormat.availableHeight);
     } else {
-      imageWidget = pw.Image(image, fit: fit, height: pageFormat.height, width: pageFormat.width);
+      imageWidget = pw.Image(image, fit: fit, height: pageFormat.availableHeight, width: pageFormat.availableWidth);
     }
 
     final doc = pw.Document(title: "MomentoBooth image");


### PR DESCRIPTION
Not as much as a bugfix as I thought it would be, initial problems were related to the printer itself acting weird. Anyway. The centering of the image in the print output is fixed.

Adds settings for sizing and positioning the print as wanted. For inspection, the generated PDF is now also saved to disk as `latest-print.pdf` in the output folder.