### PR TITLE
Live view fading

### DIFF
--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -24,6 +24,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   bool captureComplete = false;
   static const flashStartDuration = Duration(milliseconds: 50);
   static const flashEndDuration = Duration(milliseconds: 2500);
+  static const minimumContinueWait = Duration(milliseconds: 1500);
 
   int get counterStart => SettingsManagerBase.instance.settings.captureDelaySeconds;
 
@@ -81,8 +82,8 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
     showCounter = false;
     await Future.delayed(flashAnimationDuration);
     showFlash = false;
-    await Future.delayed(flashAnimationDuration);
-    flashComplete = true;
+    await Future.delayed(minimumContinueWait);
+    flashComplete = true; // Flash is now not actually complete, but after this time we do not care about it anymore.
     navigateAfterCapture();
   }
 

--- a/lib/views/custom_widgets/wrappers/live_view_background.dart
+++ b/lib/views/custom_widgets/wrappers/live_view_background.dart
@@ -77,8 +77,12 @@ class LiveViewBackground extends StatelessWidgetBase {
           imageFilter: ui.ImageFilter.blur(sigmaX: 8, sigmaY: 8),
           child: LiveView(fit: BoxFit.cover),
         ),
-        if (_showLiveViewBackground)
-          LiveView(),
+        AnimatedOpacity(
+          duration: Duration(milliseconds: 300),
+          opacity: _showLiveViewBackground ? 1 : 0,
+          curve: Curves.ease,
+          child: LiveView(),
+        ),
       ],
     );
   }

--- a/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
+++ b/lib/views/multi_capture_screen/multi_capture_screen_view_model.dart
@@ -21,6 +21,7 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
   bool captureComplete = false;
   static const flashStartDuration = Duration(milliseconds: 50);
   static const flashEndDuration = Duration(milliseconds: 2500);
+  static const minimumContinueWait = Duration(milliseconds: 1500);
 
   int get counterStart => SettingsManagerBase.instance.settings.captureDelaySeconds;
 
@@ -63,8 +64,8 @@ abstract class MultiCaptureScreenViewModelBase extends ScreenViewModelBase with 
     showCounter = false;
     await Future.delayed(flashAnimationDuration);
     showFlash = false;
-    await Future.delayed(flashAnimationDuration);
-    flashComplete = true;
+    await Future.delayed(minimumContinueWait);
+    flashComplete = true; // Flash is now not actually complete, but after this time we do not care about it anymore.
     navigateAfterCapture();
   }
 


### PR DESCRIPTION
Live view now fades in and out instead of appearing an disappearing in a binary way, which gave a feeling of something having gone wrong. This makes the wait after the flash now also feel less long.
To improve responsiveness even more, the time after moving on from capture has been reduced. The whole flash is not waited for anymore. This is not really noticeable because the opacity is already quite low while the curve remains untouched.