### PR TITLE
Fix stuttering by collage

### DIFF
--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -29,6 +29,7 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
               height: 1000,
               child: PhotoCollage(
                 key: viewModel.collageKey,
+                singleMode: true,
                 aspectRatio: 2/3
               ),
             ),

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -60,10 +60,10 @@ class PhotoCollageState extends State<PhotoCollage> {
     findTemplates();
   }
 
-  void _setInitialized(bool value) => _initialized.value = value;
+  void _setInitialized(int value) => _initialized.value = value;
 
-  final Observable<bool> _initialized = Observable(false);
-  bool get initialized => _initialized.value;
+  final Observable<int> _initialized = Observable(0);
+  int get initialized => _initialized.value;
   late Action setInitialized;
 
   ScreenshotController screenshotController = ScreenshotController(); 
@@ -88,15 +88,17 @@ class PhotoCollageState extends State<PhotoCollage> {
     if (widget.singleMode) {
       templates[TemplateKind.front]?[1] = await _templateResolver(TemplateKind.front, 1);
       templates[TemplateKind.back]?[1] = await _templateResolver(TemplateKind.back, 1);
+      setInitialized([1]);
     } else {
       for (int i = 0; i <= 4; i++) {
         final frontTemplate = await _templateResolver(TemplateKind.front, i);
         final backTemplate = await _templateResolver(TemplateKind.back, i);
         templates[TemplateKind.front]?[i] = frontTemplate;
         templates[TemplateKind.back]?[i] = backTemplate;
+        setInitialized([i+1]);
+        await Future.delayed(Duration(milliseconds: 100));
       }
     }
-    setInitialized([true]);
   }
 
   /// Checks if a given template file exists and returns it if it does.
@@ -134,7 +136,7 @@ class PhotoCollageState extends State<PhotoCollage> {
       fit: StackFit.expand,
       children: [
         for (int i = 0; i <= 4; i++) ...[
-          if (initialized && templates[TemplateKind.back]?[i] != null)
+          if (initialized > 0 && templates[TemplateKind.back]?[i] != null)
             Opacity(
               opacity: i == nChosen ? 1 : 0,
               child: Image.file(templates[TemplateKind.back]![i]!, fit: BoxFit.cover),
@@ -145,7 +147,7 @@ class PhotoCollageState extends State<PhotoCollage> {
           child: _innerLayout,
         ),
         for (int i = 0; i <= 4; i++) ...[
-          if (initialized && templates[TemplateKind.front]?[i] != null)
+          if (initialized > 0 && templates[TemplateKind.front]?[i] != null)
             Opacity(
               opacity: i == nChosen ? 1 : 0,
               child: Image.file(templates[TemplateKind.front]![i]!, fit: BoxFit.cover),

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -35,11 +35,13 @@ class PhotoCollage extends StatefulWidget {
 
   final double aspectRatio;
   final bool showLogo;
+  final bool singleMode;
 
   const PhotoCollage({
     super.key,
     required this.aspectRatio,
     this.showLogo = false,
+    this.singleMode = false,
   });
 
   @override
@@ -49,7 +51,11 @@ class PhotoCollage extends StatefulWidget {
 
 class PhotoCollageState extends State<PhotoCollage> {
 
-  PhotoCollageState() {
+  PhotoCollageState();
+
+  @override
+  void initState() {
+    super.initState();
     setInitialized = Action(_setInitialized);
     findTemplates();
   }
@@ -79,17 +85,19 @@ class PhotoCollageState extends State<PhotoCollage> {
   };
   
   void findTemplates() async {
-    for (int i = 0; i <= 4; i++) {
-      final frontTemplate = await _templateResolver(TemplateKind.front, i);
-      final backTemplate = await _templateResolver(TemplateKind.back, i);
-      templates[TemplateKind.front]?[i] = frontTemplate;
-      templates[TemplateKind.back]?[i] = backTemplate;
+    if (widget.singleMode) {
+      templates[TemplateKind.front]?[1] = await _templateResolver(TemplateKind.front, 1);
+      templates[TemplateKind.back]?[1] = await _templateResolver(TemplateKind.back, 1);
+    } else {
+      for (int i = 0; i <= 4; i++) {
+        final frontTemplate = await _templateResolver(TemplateKind.front, i);
+        final backTemplate = await _templateResolver(TemplateKind.back, i);
+        templates[TemplateKind.front]?[i] = frontTemplate;
+        templates[TemplateKind.back]?[i] = backTemplate;
+      }
     }
     setInitialized([true]);
   }
-
-  File? get frontTemplate => templates[TemplateKind.front]?[nChosen];
-  File? get backTemplate => templates[TemplateKind.back]?[nChosen];
 
   /// Checks if a given template file exists and returns it if it does.
   Future<File?> _templateTest(String fileName) async {


### PR DESCRIPTION
The collage template loading was causing stuttering in the first second of the single capture. This has been solved by making sure it only loads the templates for the single-layout.
Additionally, the decoding load has been spread for "normal" mode, when all templates are loaded.