### PR TITLE
Fix memory usage when Dart code is paused

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,15 +61,17 @@ class _AppState extends State<App> with UiLoggy {
   bool _settingsOpen = false;
   bool _isFullScreen = false;
 
-  static final returnHomeTimeout = Duration(seconds: 45);
-  late Timer _returnHome;
+  static const returnHomeTimeout = Duration(seconds: 45);
+  static const updateLastAliveTimeout = Duration(milliseconds: 100);
+  late Timer _returnHomeTimer, _updateLastAliveTimeTimer;
 
   @override
   void initState() {
     _initHotKeys();
     // Check if the window is fullscreen from the start.
     windowManager.isFullScreen().then((value) => _isFullScreen = value);
-    _returnHome = Timer(returnHomeTimeout, _goHome);
+    _returnHomeTimer = Timer(returnHomeTimeout, _returnHome);
+    _updateLastAliveTimeTimer = Timer.periodic(updateLastAliveTimeout, _updateLastAliveTime);
     _router.addListener(() { onActivity(null); });
     super.initState();
   }
@@ -114,16 +116,20 @@ class _AppState extends State<App> with UiLoggy {
     );
   }
 
-  void _goHome() {
+  void _returnHome() {
     loggy.debug("No activity in $returnHomeTimeout, returning to homescreen");
     _router.go(StartScreen.defaultRoute);
+  }
+
+  void _updateLastAliveTime(Timer timer) {
+    rustLibraryApi.updateFlutterAppAlive();
   }
 
   /// Method that is fired when a user does any kind of touch or the route changes.
   /// This resets the return home timer.
   void onActivity(PointerEvent? event) {
-    _returnHome.cancel();
-    _returnHome = Timer(returnHomeTimeout, _goHome);
+    _returnHomeTimer.cancel();
+    _returnHomeTimer = Timer(returnHomeTimeout, _returnHome);
   }
 
   @override

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -300,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1673,7 @@ dependencies = [
  "nokhwa-bindings-macos 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "serde_json",
+ "static_init",
  "zune-jpeg",
 ]
 
@@ -1971,6 +1978,17 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api 0.4.9",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
@@ -1991,6 +2009,20 @@ dependencies = [
  "redox_syscall 0.1.57",
  "rustc_version 0.2.3",
  "smallvec 0.6.14",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec 1.10.0",
  "winapi 0.3.9",
 ]
 
@@ -2656,6 +2688,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check 0.9.4",
+]
+
+[[package]]
+name = "static_init"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg_aliases",
+ "libc",
+ "parking_lot 0.11.2",
+ "parking_lot_core 0.8.6",
+ "static_init_macro",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "static_init_macro"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
+dependencies = [
+ "cfg_aliases",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,7 @@ nokhwa-bindings-macos = "0.2.0"
 nokhwa = { git = "https://github.com/RReverser/nokhwa.git", branch="fix-callback-camera-deadlock", features = ["input-native", "output-threaded"] }
 zune-jpeg = "0.3.16"
 jpeg-encoder = "0.5.1"
+static_init = "1.0.3"
 
 # Make debug builds as fast as release
 [profile.dev.package."*"]

--- a/rust/src/utils/image_processing.rs
+++ b/rust/src/utils/image_processing.rs
@@ -6,6 +6,7 @@ use crate::dart_bridge::api::RawImage;
 // Structs and Main Operations //
 // /////////////////////////// //
 
+#[derive(Clone, Copy)]
 pub enum ImageOperation {
     CropToAspectRatio(f64),
     Rotate(Rotation),


### PR DESCRIPTION
This PR adds a simple timing based system for the Rust library to check whether the Flutter app is still alive. If it seems is isn't, the library will no longer add new camera frames to the pipe.

This should fix very high memory usage whenever the Flutter part of the app is paused (e.g. due to the app being paused by the debugger)