### PR TITLE
Collage sizing settings

### DIFF
--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -21,6 +21,7 @@ class Settings with _$Settings implements TomlEncodableValue {
   const factory Settings({
     required int captureDelaySeconds,
     required bool displayConfetti,
+    required double collageAspectRatio,
     required bool singlePhotoIsCollage,
     required String templatesFolder,
     required HardwareSettings hardware,
@@ -30,6 +31,7 @@ class Settings with _$Settings implements TomlEncodableValue {
   factory Settings.withDefaults() {
     return Settings(
       captureDelaySeconds: 5,
+      collageAspectRatio: 1.5,
       displayConfetti: true,
       singlePhotoIsCollage: true,
       templatesFolder: _getHome(),

--- a/lib/models/settings.dart
+++ b/lib/models/settings.dart
@@ -22,6 +22,7 @@ class Settings with _$Settings implements TomlEncodableValue {
     required int captureDelaySeconds,
     required bool displayConfetti,
     required double collageAspectRatio,
+    required double collagePadding,
     required bool singlePhotoIsCollage,
     required String templatesFolder,
     required HardwareSettings hardware,
@@ -32,6 +33,7 @@ class Settings with _$Settings implements TomlEncodableValue {
     return Settings(
       captureDelaySeconds: 5,
       collageAspectRatio: 1.5,
+      collagePadding: 0,
       displayConfetti: true,
       singlePhotoIsCollage: true,
       templatesFolder: _getHome(),

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -30,7 +30,7 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
               child: PhotoCollage(
                 key: viewModel.collageKey,
                 singleMode: true,
-                aspectRatio: 2/3,
+                aspectRatio: 1/viewModel.collageAspectRatio,
                 decodeCallback: viewModel.collageReady,
               ),
             ),

--- a/lib/views/capture_screen/capture_screen_view.dart
+++ b/lib/views/capture_screen/capture_screen_view.dart
@@ -25,14 +25,12 @@ class CaptureScreenView extends ScreenViewBase<CaptureScreenViewModel, CaptureSc
         FittedBox(
           child: Transform.translate(
             offset: Offset(3000, 0),
-            child: SizedBox(
-              height: 1000,
-              child: PhotoCollage(
-                key: viewModel.collageKey,
-                singleMode: true,
-                aspectRatio: 1/viewModel.collageAspectRatio,
-                decodeCallback: viewModel.collageReady,
-              ),
+            child: PhotoCollage(
+              key: viewModel.collageKey,
+              singleMode: true,
+              aspectRatio: 1/viewModel.collageAspectRatio,
+              padding: viewModel.collagePadding,
+              decodeCallback: viewModel.collageReady,
             ),
           ),
         ),

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -31,6 +31,7 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
   int get counterStart => SettingsManagerBase.instance.settings.captureDelaySeconds;
 
   double get collageAspectRatio => SettingsManagerBase.instance.settings.collageAspectRatio;
+  double get collagePadding => SettingsManagerBase.instance.settings.collagePadding;
 
   @computed
   Duration get photoDelay => Duration(seconds: counterStart) - capturer.captureDelay + flashStartDuration;

--- a/lib/views/capture_screen/capture_screen_view_model.dart
+++ b/lib/views/capture_screen/capture_screen_view_model.dart
@@ -30,6 +30,8 @@ abstract class CaptureScreenViewModelBase extends ScreenViewModelBase with Store
 
   int get counterStart => SettingsManagerBase.instance.settings.captureDelaySeconds;
 
+  double get collageAspectRatio => SettingsManagerBase.instance.settings.collageAspectRatio;
+
   @computed
   Duration get photoDelay => Duration(seconds: counterStart) - capturer.captureDelay + flashStartDuration;
 

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -159,7 +159,7 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
               height: 1000,
               child: PhotoCollage(
                 key: controller.collageKey,
-                aspectRatio: 2/3
+                aspectRatio: 1/viewModel.collageAspectRatio,
               ),
             ),
           ),

--- a/lib/views/collage_maker_screen/collage_maker_screen_view.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view.dart
@@ -155,12 +155,10 @@ class CollageMakerScreenView extends ScreenViewBase<CollageMakerScreenViewModel,
             boxShadow: [theme.chooseCaptureModeButtonShadow],
           ),
           child: FittedBox(
-            child: SizedBox(
-              height: 1000,
-              child: PhotoCollage(
-                key: controller.collageKey,
-                aspectRatio: 1/viewModel.collageAspectRatio,
-              ),
+            child: PhotoCollage(
+              key: controller.collageKey,
+              aspectRatio: 1/viewModel.collageAspectRatio,
+              padding: viewModel.collagePadding,
             ),
           ),
         ),

--- a/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
@@ -16,6 +16,7 @@ abstract class CollageMakerScreenViewModelBase extends ScreenViewModelBase with 
   int get numSelected => PhotosManagerBase.instance.chosen.length;
   
   double get collageAspectRatio => SettingsManagerBase.instance.settings.collageAspectRatio;
+  double get collagePadding => SettingsManagerBase.instance.settings.collagePadding;
 
   int get rotation => [0, 1, 4].contains(numSelected) ? 1 : 0;
   

--- a/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
+++ b/lib/views/collage_maker_screen/collage_maker_screen_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:mobx/mobx.dart';
 
@@ -13,6 +14,8 @@ abstract class CollageMakerScreenViewModelBase extends ScreenViewModelBase with 
   });
 
   int get numSelected => PhotosManagerBase.instance.chosen.length;
+  
+  double get collageAspectRatio => SettingsManagerBase.instance.settings.collageAspectRatio;
 
   int get rotation => [0, 1, 4].contains(numSelected) ? 1 : 0;
   

--- a/lib/views/custom_widgets/photo_collage.dart
+++ b/lib/views/custom_widgets/photo_collage.dart
@@ -38,6 +38,7 @@ void baseCallback() {}
 class PhotoCollage extends StatefulWidget {
 
   final double aspectRatio;
+  final double padding;
   final bool showLogo;
   final bool singleMode;
   final Function decodeCallback;
@@ -45,6 +46,7 @@ class PhotoCollage extends StatefulWidget {
   const PhotoCollage({
     super.key,
     required this.aspectRatio,
+    this.padding = 0,
     this.showLogo = false,
     this.singleMode = false,
     this.decodeCallback = baseCallback,
@@ -131,9 +133,10 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
   Widget build(BuildContext context) {
     return Screenshot(
       controller: screenshotController,
-      child: AspectRatio(
-        aspectRatio: widget.aspectRatio,
-        child: Observer(builder: (context) => _layout)
+      child: SizedBox(
+        height: 1000 + 2*widget.padding,
+        width: 1000*widget.aspectRatio + 2*widget.padding,
+        child: Observer(builder: (context) => _layout),
       ),
     );
   }
@@ -150,7 +153,7 @@ class PhotoCollageState extends State<PhotoCollage> with UiLoggy {
             ),
         ],
         Padding(
-          padding: const EdgeInsets.all(gap),
+          padding: EdgeInsets.all(gap + widget.padding),
           child: _innerLayout,
         ),
         for (int i = 0; i <= 4; i++) ...[

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -42,6 +42,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onCollagePaddingChanged(double? collagePadding) {
+    if (collagePadding != null) {
+      viewModel.updateSettings((settings) => settings.copyWith(collagePadding: collagePadding));
+    }
+  }
+
   void onDisplayConfettiChanged(bool? displayConfetti) {
     if (displayConfetti != null) {
       viewModel.updateSettings((settings) => settings.copyWith(displayConfetti: displayConfetti));

--- a/lib/views/settings_screen/settings_screen_controller.dart
+++ b/lib/views/settings_screen/settings_screen_controller.dart
@@ -36,6 +36,12 @@ class SettingsScreenController extends ScreenControllerBase<SettingsScreenViewMo
     }
   }
 
+  void onCollageAspectRatioChanged(double? collageAspectRatio) {
+    if (collageAspectRatio != null) {
+      viewModel.updateSettings((settings) => settings.copyWith(collageAspectRatio: collageAspectRatio));
+    }
+  }
+
   void onDisplayConfettiChanged(bool? displayConfetti) {
     if (displayConfetti != null) {
       viewModel.updateSettings((settings) => settings.copyWith(displayConfetti: displayConfetti));

--- a/lib/views/settings_screen/settings_screen_view.general.dart
+++ b/lib/views/settings_screen/settings_screen_view.general.dart
@@ -21,13 +21,6 @@ Widget _getGeneralSettings(SettingsScreenViewModel viewModel, SettingsScreenCont
             value: () => viewModel.displayConfettiSetting,
             onChanged: controller.onDisplayConfettiChanged,
           ),
-          _getInput(
-            icon: FluentIcons.aspect_ratio,
-            title: "Collage aspect ratio",
-            subtitle: "Controls the aspect ratio of the generated collages. Think about this together with paper print size.",
-            value: () => viewModel.collageAspectRatioSetting,
-            onChanged: controller.onCollageAspectRatioChanged,
-          ),
           Padding(
             padding: const EdgeInsets.only(top: 8.0),
             child: Text("Hit Ctrl+F or Alt+Enter to toggle fullscreen mode."),
@@ -37,6 +30,26 @@ Widget _getGeneralSettings(SettingsScreenViewModel viewModel, SettingsScreenCont
       FluentSettingsBlock(
         title: "Creative",
         settings: [
+          _getInput(
+            icon: FluentIcons.aspect_ratio,
+            title: "Collage aspect ratio",
+            subtitle: "Controls the aspect ratio of the generated collages. Think about this together with paper print size.",
+            value: () => viewModel.collageAspectRatioSetting,
+            onChanged: controller.onCollageAspectRatioChanged,
+          ),
+          _getInput(
+            icon: FluentIcons.field_filled,
+            title: "Collage padding",
+            subtitle: "Controls the padding around the aspect ratio of the generated collages. Think about this together with paper print size.",
+            value: () => viewModel.collagePaddingSetting,
+            onChanged: controller.onCollagePaddingChanged,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: Observer(
+              builder: (context) => Text("→ Padding will be ${(viewModel.pageHeightSetting/1000 * viewModel.collagePaddingSetting).toStringAsPrecision(3)} mm with ${viewModel.pageHeightSetting} mm page height.")
+            ),
+          ),
           _getFolderPickerCard(
             icon: FluentIcons.fabric_report_library,
             title: "Collage background templates location",

--- a/lib/views/settings_screen/settings_screen_view.general.dart
+++ b/lib/views/settings_screen/settings_screen_view.general.dart
@@ -21,6 +21,13 @@ Widget _getGeneralSettings(SettingsScreenViewModel viewModel, SettingsScreenCont
             value: () => viewModel.displayConfettiSetting,
             onChanged: controller.onDisplayConfettiChanged,
           ),
+          _getInput(
+            icon: FluentIcons.aspect_ratio,
+            title: "Collage aspect ratio",
+            subtitle: "Controls the aspect ratio of the generated collages. Think about this together with paper print size.",
+            value: () => viewModel.collageAspectRatioSetting,
+            onChanged: controller.onCollageAspectRatioChanged,
+          ),
           Padding(
             padding: const EdgeInsets.only(top: 8.0),
             child: Text("Hit Ctrl+F or Alt+Enter to toggle fullscreen mode."),

--- a/lib/views/settings_screen/settings_screen_view.output.dart
+++ b/lib/views/settings_screen/settings_screen_view.output.dart
@@ -57,7 +57,7 @@ Widget _getOutputSettings(SettingsScreenViewModel viewModel, SettingsScreenContr
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Text("Output resolution will be ${(viewModel.resolutionMultiplier*1000).round()}×${(viewModel.resolutionMultiplier*2000/3).round()}"),
+            child: Text("Output resolution based on aspect ratio (${viewModel.collageAspectRatioSetting}) and multiplier will be ${(viewModel.resolutionMultiplier*1000).round()}×${(viewModel.resolutionMultiplier*1000/viewModel.collageAspectRatioSetting).round()}"),
           ),
         ],
       ),

--- a/lib/views/settings_screen/settings_screen_view.output.dart
+++ b/lib/views/settings_screen/settings_screen_view.output.dart
@@ -57,7 +57,7 @@ Widget _getOutputSettings(SettingsScreenViewModel viewModel, SettingsScreenContr
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
-            child: Text("Output resolution based on aspect ratio (${viewModel.collageAspectRatioSetting}) and multiplier will be ${(viewModel.resolutionMultiplier*1000).round()}×${(viewModel.resolutionMultiplier*1000/viewModel.collageAspectRatioSetting).round()}"),
+            child: Text("→ Output resolution based on aspect ratio (${viewModel.collageAspectRatioSetting}) and padding (${viewModel.collagePaddingSetting}) and multiplier will be ${(viewModel.outputResHeightExcl).round()}×${(viewModel.outputResWidthExcl).round()} without and ${(viewModel.outputResHeightIncl).round()}×${(viewModel.outputResWidthIncl).round()} with padding"),
           ),
         ],
       ),

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -63,6 +63,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
 
   int get captureDelaySecondsSetting => SettingsManagerBase.instance.settings.captureDelaySeconds;
   bool get displayConfettiSetting => SettingsManagerBase.instance.settings.displayConfetti;
+  double get collageAspectRatioSetting => SettingsManagerBase.instance.settings.collageAspectRatio;
   bool get singlePhotoIsCollageSetting => SettingsManagerBase.instance.settings.singlePhotoIsCollage;
   String get templatesFolderSetting => SettingsManagerBase.instance.settings.templatesFolder;
   LiveViewMethod get liveViewMethodSetting => SettingsManagerBase.instance.settings.hardware.liveViewMethod;

--- a/lib/views/settings_screen/settings_screen_view_model.dart
+++ b/lib/views/settings_screen/settings_screen_view_model.dart
@@ -64,6 +64,7 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   int get captureDelaySecondsSetting => SettingsManagerBase.instance.settings.captureDelaySeconds;
   bool get displayConfettiSetting => SettingsManagerBase.instance.settings.displayConfetti;
   double get collageAspectRatioSetting => SettingsManagerBase.instance.settings.collageAspectRatio;
+  double get collagePaddingSetting => SettingsManagerBase.instance.settings.collagePadding;
   bool get singlePhotoIsCollageSetting => SettingsManagerBase.instance.settings.singlePhotoIsCollage;
   String get templatesFolderSetting => SettingsManagerBase.instance.settings.templatesFolder;
   LiveViewMethod get liveViewMethodSetting => SettingsManagerBase.instance.settings.hardware.liveViewMethod;
@@ -85,6 +86,11 @@ abstract class SettingsScreenViewModelBase extends ScreenViewModelBase with Stor
   ExportFormat get exportFormat => SettingsManagerBase.instance.settings.output.exportFormat;
   int get jpgQuality => SettingsManagerBase.instance.settings.output.jpgQuality;
   double get resolutionMultiplier => SettingsManagerBase.instance.settings.output.resolutionMultiplier;
+
+  double get outputResHeightExcl => resolutionMultiplier * 1000;
+  double get outputResWidthExcl => outputResHeightExcl/collageAspectRatioSetting;
+  double get outputResHeightIncl => outputResHeightExcl + collagePaddingSetting * 2 * resolutionMultiplier;
+  double get outputResWidthIncl => outputResWidthExcl + collagePaddingSetting * 2 * resolutionMultiplier;
 
   // Initializers/Deinitializers
 


### PR DESCRIPTION
After a lot of testing with the printer, it became clear that more control was required to get a good print. Two settings have been added to control image generation such that the desired resulting print can be achieved.

1. Aspect ratio
The photo paper may not be 3:2 exactly, so to make a generated image fit, the aspect ratio has to be correct.
2. Padding
No printer has perfect alignment, so adding a bit of padding helps to prevent white borders showing while retaining the desired layout. The padding is applied _around_ the aspect ratio/content. The back and foregrounds cover the entire area inc. padding.