### PR TITLE
Manual collages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:momento_booth/views/choose_capture_mode_screen/choose_capture_mo
 import 'package:momento_booth/views/collage_maker_screen/collage_maker_screen.dart';
 import 'package:momento_booth/views/custom_widgets/wrappers/live_view_background.dart';
 import 'package:momento_booth/views/gallery_screen/gallery_screen.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen.dart';
 import 'package:momento_booth/views/multi_capture_screen/multi_capture_screen.dart';
 import 'package:momento_booth/views/photo_details_screen/photo_details_screen.dart';
 import 'package:momento_booth/views/share_screen/share_screen.dart';
@@ -89,6 +90,7 @@ class _AppState extends State<App> with UiLoggy {
   }
 
   void _initHotKeys() {
+    // Ctrl + S opens/closes settings
     hotKeyManager.register(
       HotKey(
         KeyCode.keyS,
@@ -100,6 +102,22 @@ class _AppState extends State<App> with UiLoggy {
         loggy.debug("Settings ${_settingsOpen ? "opened" : "closed"}");
       },
     );
+    // Ctrl + M opens manual collage maker screen
+    hotKeyManager.register(
+      HotKey(
+        KeyCode.keyM,
+        modifiers: [KeyModifier.control],
+        scope: HotKeyScope.inapp,
+      ),
+      keyDownHandler: (hotKey) {
+        if (_router.location == ManualCollageScreen.defaultRoute) {
+          _router.go(StartScreen.defaultRoute);
+        } else {
+          _router.go(ManualCollageScreen.defaultRoute);
+        }
+      },
+    );
+    // Alt + enter toggles full-screen
     hotKeyManager.register(
       HotKey(
         KeyCode.enter,
@@ -110,6 +128,7 @@ class _AppState extends State<App> with UiLoggy {
         setState(_toggleFullscreen);
       },
     );
+    // Ctrl + F toggles full-screen
     hotKeyManager.register(
       HotKey(
         KeyCode.keyF,

--- a/lib/main.routes.dart
+++ b/lib/main.routes.dart
@@ -9,6 +9,7 @@ List<GoRoute> rootRoutes = [
   _shareRoute,
   _galleryRoute,
   _photoDetailsRoute,
+  _manualCollageRoute,
   _settingsRoute,
 ];
 
@@ -88,6 +89,16 @@ GoRoute _photoDetailsRoute = GoRoute(
     return FadeTransitionPage(
       key: state.pageKey,
       child: PhotoDetailsScreen(photoId: state.pathParameters['pid']!),
+    );
+  },
+);
+
+GoRoute _manualCollageRoute = GoRoute(
+  path: "${ManualCollageScreen.defaultRoute}",
+  pageBuilder: (context, state) {
+    return FadeTransitionPage(
+      key: state.pageKey,
+      child: ManualCollageScreen(),
     );
   },
 );

--- a/lib/managers/photos_manager.dart
+++ b/lib/managers/photos_manager.dart
@@ -63,7 +63,7 @@ abstract class PhotosManagerBase with Store {
   }
 
   @action
-  Future<File?> writeOutput() async {
+  Future<File?> writeOutput({bool advance = false}) async {
     if (instance.outputImage == null) return null;
     if (!photoNumberChecked) {
       photoNumber = await findLastImageNumber()+1;
@@ -72,7 +72,9 @@ abstract class PhotosManagerBase with Store {
     final extension = SettingsManagerBase.instance.settings.output.exportFormat.name.toLowerCase();
     final filePath = join(outputDir.path, '$baseName-${photoNumber.toString().padLeft(4, '0')}.$extension');
     File file = await File(filePath).create();
-    return await file.writeAsBytes(instance.outputImage!);
+    await file.writeAsBytes(instance.outputImage!);
+    if (advance) { photoNumber++; }
+    return file;
   }
   
   @action

--- a/lib/views/manual_collage_screen/manual_collage_screen.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen.dart
@@ -1,0 +1,28 @@
+import 'package:momento_booth/views/base/build_context_accessor.dart';
+import 'package:momento_booth/views/base/screen_base.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_controller.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view.dart';
+
+class ManualCollageScreen extends ScreenBase<ManualCollageScreenViewModel, ManualCollageScreenController, ManualCollageScreenView> {
+  
+  static const String defaultRoute = "/manual-collage";
+
+  const ManualCollageScreen({super.key});
+
+  @override
+  ManualCollageScreenController createController({required ManualCollageScreenViewModel viewModel, required BuildContextAccessor contextAccessor}) {
+    return ManualCollageScreenController(viewModel: viewModel, contextAccessor: contextAccessor);
+  }
+
+  @override
+  ManualCollageScreenView createView({required ManualCollageScreenController controller, required ManualCollageScreenViewModel viewModel, required BuildContextAccessor contextAccessor}) {
+    return ManualCollageScreenView(viewModel: viewModel, controller: controller, contextAccessor: contextAccessor);
+  }
+
+  @override
+  ManualCollageScreenViewModel createViewModel({required BuildContextAccessor contextAccessor}) {
+    return ManualCollageScreenViewModel(contextAccessor: contextAccessor);
+  }
+
+}

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -1,7 +1,14 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:loggy/loggy.dart';
+import 'package:momento_booth/managers/photos_manager.dart';
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_controller_base.dart';
+import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
 
-class ManualCollageScreenController extends ScreenControllerBase<ManualCollageScreenViewModel> {
+class ManualCollageScreenController extends ScreenControllerBase<ManualCollageScreenViewModel> with UiLoggy {
 
   // Initialization/Deinitialization
 
@@ -9,5 +16,41 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     required super.viewModel,
     required super.contextAccessor,
   });
+
+  /// Global key for controlling the slider widget.
+  GlobalKey<PhotoCollageState> collageKey = GlobalKey<PhotoCollageState>();
+
+  void tapPhoto(File file) {
+    
+  }
+
+  void togglePicture(int image) {
+    if (PhotosManagerBase.instance.chosen.contains(image)) {
+      PhotosManagerBase.instance.chosen.remove(image);
+    } else {
+      PhotosManagerBase.instance.chosen.add(image);
+    }
+    captureCollage();
+  }
+
+  String get outputFolder => SettingsManagerBase.instance.settings.output.localFolder;
+
+  DateTime? latestCapture;
+
+  void captureCollage() async {
+    
+    if (viewModel.numSelected < 1) return;
+
+    final stopwatch = Stopwatch()..start();
+    final pixelRatio = SettingsManagerBase.instance.settings.output.resolutionMultiplier;
+    final format = SettingsManagerBase.instance.settings.output.exportFormat;
+    final jpgQuality = SettingsManagerBase.instance.settings.output.jpgQuality;
+    final exportImage = await collageKey.currentState!.getCollageImage(pixelRatio: pixelRatio, format: format, jpgQuality: jpgQuality);
+    loggy.debug('captureCollage took ${stopwatch.elapsed}');
+  
+    PhotosManagerBase.instance.outputImage = exportImage;
+    loggy.debug("Written collage image to output image memory");
+    PhotosManagerBase.instance.writeOutput();
+  }
 
 }

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -23,6 +23,11 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
 
   final selectedPhotos = <SelectableImage>[];
 
+  void refreshImageList() {
+    clearSelection();
+    viewModel.findImages();
+  }
+
   void clearSelection() {
     for (var photo in selectedPhotos) {
       photo.isSelected= false;

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -1,0 +1,13 @@
+import 'package:momento_booth/views/base/screen_controller_base.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
+
+class ManualCollageScreenController extends ScreenControllerBase<ManualCollageScreenViewModel> {
+
+  // Initialization/Deinitialization
+
+  ManualCollageScreenController({
+    required super.viewModel,
+    required super.contextAccessor,
+  });
+
+}

--- a/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_controller.dart
@@ -58,19 +58,14 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
       PhotosManagerBase.instance.chosen.add(index);
       viewModel.numSelected = index+1;
     }
-    captureCollage();
   }
 
   String get outputFolder => SettingsManagerBase.instance.settings.output.localFolder;
 
-  DateTime? latestCapture;
-
-  late Completer captureComplete;
-
   void captureCollage() async {
-    if (viewModel.numSelected < 1) return;
+    if (viewModel.numSelected < 1 || viewModel.isSaving) return;
 
-    captureComplete = Completer();
+    viewModel.isSaving = true;
     final stopwatch = Stopwatch()..start();
     final pixelRatio = SettingsManagerBase.instance.settings.output.resolutionMultiplier;
     final format = SettingsManagerBase.instance.settings.output.exportFormat;
@@ -79,14 +74,9 @@ class ManualCollageScreenController extends ScreenControllerBase<ManualCollageSc
     loggy.debug('captureCollage took ${stopwatch.elapsed}');
   
     PhotosManagerBase.instance.outputImage = exportImage;
-    loggy.debug("Written collage image to output image memory");
-    captureComplete.complete();
-  }
-
-  void saveCollage() async {
-    await captureComplete.future;
     PhotosManagerBase.instance.writeOutput(advance: true);
     loggy.debug("Saved collage image to disk");
+    viewModel.isSaving = false;
   }
 
 }

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -95,9 +95,15 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
                   onTap: controller.clearSelection,
                   child: AutoSizeText("Clear", style: theme.titleStyle,)
                 ),
-                GestureDetector(
-                  onTap: controller.saveCollage,
-                  child: AutoSizeText("Save", style: theme.titleStyle,)
+                Observer(
+                  builder: (context) => AnimatedOpacity(
+                    duration: viewModel.opacityDuraction,
+                    opacity: viewModel.isSaving ? 0.5 : 1,
+                    child: GestureDetector(
+                      onTap: controller.captureCollage,
+                      child: AutoSizeText(viewModel.isSaving ? "Saving..." : "Save", style: theme.titleStyle,)
+                    ),
+                  ),
                 ),
               ],
             )

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -1,5 +1,12 @@
+import 'dart:io';
+
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
+import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
+import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_controller.dart';
 import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
 
@@ -13,7 +20,113 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
   
   @override
   Widget get body {
-    return Text("Hello from ManualCollageScreen!");
+    return Row(
+      children: [
+        Flexible(child: _photoGrid),
+        Flexible(
+          fit: FlexFit.tight,
+          child: _rightColumn
+        ),
+      ],
+    );
+  }
+
+  Widget _photoInst(File file, int i) {
+    return Observer(
+      builder: (BuildContext context) {
+        return Stack(
+          children: [
+            ImageWithLoaderFallback.file(file, fit: BoxFit.contain),
+            AnimatedOpacity(
+              opacity: PhotosManagerBase.instance.chosen.contains(i) ? 1 : 0,
+              duration: Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  ColoredBox(color: Color(0x80000000)),
+                  Center(
+                    child: Text((PhotosManagerBase.instance.chosen.indexOf(i)+1).toString(), style: theme.subTitleStyle,),
+                  ),
+                ],
+              ),
+            )
+          ],
+        );
+      }
+    );
+  }
+
+  Widget get _photoGrid {
+    return Observer(
+      builder: (context) => GridView.count(
+        padding: EdgeInsets.symmetric(horizontal: 30, vertical: 10),
+        mainAxisSpacing: 20,
+        crossAxisSpacing: 20,
+        crossAxisCount: 4,
+        childAspectRatio: 1.5,
+        children: [
+          for (var file in viewModel.fileList)
+            GestureDetector(
+              onTap: () => controller.tapPhoto(file),
+              child: _photoInst(file, 0),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget get _rightColumn {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 30),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Flexible(
+            flex: 1,
+            child: SizedBox()
+          ),
+          Expanded(
+            flex: 10,
+            child: _collage,
+          ),
+          Flexible(
+            flex: 2,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: GestureDetector(
+                onTap: controller.captureCollage,
+                child: AutoSizeText("Save", style: theme.titleStyle,)
+              ),
+            )
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget get _collage {
+    return Observer(
+      builder: (context) => AnimatedRotation(
+        duration: Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+        turns: -0.25 * viewModel.rotation, // could also use controller.collageKey.currentState!.rotation
+        child: Container(
+          decoration: BoxDecoration(
+            color: Color.fromARGB(255, 255, 255, 255),
+            boxShadow: [theme.chooseCaptureModeButtonShadow],
+          ),
+          child: FittedBox(
+            child: PhotoCollage(
+              key: controller.collageKey,
+              aspectRatio: 1/viewModel.collageAspectRatio,
+              padding: viewModel.collagePadding,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
 }

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/widgets.dart';
+import 'package:momento_booth/views/base/screen_view_base.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_controller.dart';
+import 'package:momento_booth/views/manual_collage_screen/manual_collage_screen_view_model.dart';
+
+class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewModel, ManualCollageScreenController> {
+
+  const ManualCollageScreenView({
+    required super.viewModel,
+    required super.controller,
+    required super.contextAccessor,
+  });
+  
+  @override
+  Widget get body {
+    return Text("Hello from ManualCollageScreen!");
+  }
+
+}

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -66,6 +66,12 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
               onTap: () => controller.tapPhoto(image),
               child: _photoInst(image),
             ),
+          Center(
+            child: GestureDetector(
+              onTap: controller.refreshImageList,
+              child: AutoSizeText("Refresh", style: theme.titleStyle),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/views/manual_collage_screen/manual_collage_screen_view.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view.dart
@@ -1,9 +1,6 @@
-import 'dart:io';
-
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:momento_booth/managers/photos_manager.dart';
 import 'package:momento_booth/views/base/screen_view_base.dart';
 import 'package:momento_booth/views/custom_widgets/image_with_loader_fallback.dart';
 import 'package:momento_booth/views/custom_widgets/photo_collage.dart';
@@ -31,29 +28,27 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
     );
   }
 
-  Widget _photoInst(File file, int i) {
+  Widget _photoInst(SelectableImage image) {
     return Observer(
-      builder: (BuildContext context) {
-        return Stack(
-          children: [
-            ImageWithLoaderFallback.file(file, fit: BoxFit.contain),
-            AnimatedOpacity(
-              opacity: PhotosManagerBase.instance.chosen.contains(i) ? 1 : 0,
-              duration: Duration(milliseconds: 200),
-              curve: Curves.easeInOut,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  ColoredBox(color: Color(0x80000000)),
-                  Center(
-                    child: Text((PhotosManagerBase.instance.chosen.indexOf(i)+1).toString(), style: theme.subTitleStyle,),
-                  ),
-                ],
-              ),
-            )
-          ],
-        );
-      }
+      builder: (context) => Stack(
+        children: [
+          ImageWithLoaderFallback.file(image.file, fit: BoxFit.contain),
+          AnimatedOpacity(
+            opacity: image.isSelected ? 1 : 0,
+            duration: Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                ColoredBox(color: Color(0x80000000)),
+                Center(
+                  child: Text("${image.selectedIndex+1}/${viewModel.numSelected}", style: theme.subTitleStyle,),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
     );
   }
 
@@ -66,10 +61,10 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
         crossAxisCount: 4,
         childAspectRatio: 1.5,
         children: [
-          for (var file in viewModel.fileList)
+          for (var image in viewModel.fileList)
             GestureDetector(
-              onTap: () => controller.tapPhoto(file),
-              child: _photoInst(file, 0),
+              onTap: () => controller.tapPhoto(image),
+              child: _photoInst(image),
             ),
         ],
       ),
@@ -93,12 +88,18 @@ class ManualCollageScreenView extends ScreenViewBase<ManualCollageScreenViewMode
           ),
           Flexible(
             flex: 2,
-            child: Padding(
-              padding: const EdgeInsets.only(bottom: 10),
-              child: GestureDetector(
-                onTap: controller.captureCollage,
-                child: AutoSizeText("Save", style: theme.titleStyle,)
-              ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                GestureDetector(
+                  onTap: controller.clearSelection,
+                  child: AutoSizeText("Clear", style: theme.titleStyle,)
+                ),
+                GestureDetector(
+                  onTap: controller.saveCollage,
+                  child: AutoSizeText("Save", style: theme.titleStyle,)
+                ),
+              ],
             )
           ),
         ],

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -42,6 +42,9 @@ abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with
   String directoryString = SettingsManagerBase.instance.settings.hardware.captureLocation;
 
   Directory get outputDir => Directory(directoryString);
+
+  @observable
+  bool isSaving = false;
   
   @observable
   ObservableList<SelectableImage> fileList = ObservableList<SelectableImage>();

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -1,0 +1,14 @@
+import 'package:momento_booth/views/base/screen_view_model_base.dart';
+import 'package:mobx/mobx.dart';
+
+part 'manual_collage_screen_view_model.g.dart';
+
+class ManualCollageScreenViewModel = ManualCollageScreenViewModelBase with _$ManualCollageScreenViewModel;
+
+abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with Store {
+
+  ManualCollageScreenViewModelBase({
+    required super.contextAccessor,
+  });
+
+}

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:loggy/loggy.dart';
 import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:mobx/mobx.dart';
@@ -20,7 +21,7 @@ class SelectableImage {
   });
 }
 
-abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with Store {
+abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with Store, UiLoggy {
 
   ManualCollageScreenViewModelBase({
     required super.contextAccessor,
@@ -51,14 +52,16 @@ abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with
 
   @action
   Future<void> findImages() async {
-    fileList.clear();
+    loggy.debug("Searching for images");
     final fileListBefore = await outputDir.list().toList();
     final matchingFiles = fileListBefore.whereType<File>().where((file) => file.path.toLowerCase().endsWith('.jpg'));
 
+    fileList.clear();
     int i = 0;
     for (var file in matchingFiles) {
       fileList.add(SelectableImage(file: file, index: i++));
     }
+    loggy.debug("Found ${matchingFiles.length} images");
   }
 
 }

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -8,6 +8,18 @@ part 'manual_collage_screen_view_model.g.dart';
 
 class ManualCollageScreenViewModel = ManualCollageScreenViewModelBase with _$ManualCollageScreenViewModel;
 
+class SelectableImage {
+  late final File file;
+  bool isSelected = false;
+  int selectedIndex = 0;
+  late final int index;
+
+  SelectableImage({
+    required this.file,
+    required this.index,
+  });
+}
+
 abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with Store {
 
   ManualCollageScreenViewModelBase({
@@ -32,14 +44,18 @@ abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with
   Directory get outputDir => Directory(directoryString);
   
   @observable
-  ObservableList<File> fileList = ObservableList<File>();
+  ObservableList<SelectableImage> fileList = ObservableList<SelectableImage>();
 
   @action
   Future<void> findImages() async {
     fileList.clear();
     final fileListBefore = await outputDir.list().toList();
     final matchingFiles = fileListBefore.whereType<File>().where((file) => file.path.toLowerCase().endsWith('.jpg'));
-    for (var file in matchingFiles) { fileList.add(file); }
+
+    int i = 0;
+    for (var file in matchingFiles) {
+      fileList.add(SelectableImage(file: file, index: i++));
+    }
   }
 
 }

--- a/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
+++ b/lib/views/manual_collage_screen/manual_collage_screen_view_model.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:momento_booth/managers/settings_manager.dart';
 import 'package:momento_booth/views/base/screen_view_model_base.dart';
 import 'package:mobx/mobx.dart';
 
@@ -9,6 +12,34 @@ abstract class ManualCollageScreenViewModelBase extends ScreenViewModelBase with
 
   ManualCollageScreenViewModelBase({
     required super.contextAccessor,
-  });
+  }) {
+    findImages();
+  }
+
+  @observable
+  int numSelected = 0;
+
+  double get collageAspectRatio => SettingsManagerBase.instance.settings.collageAspectRatio;
+  double get collagePadding => SettingsManagerBase.instance.settings.collagePadding;
+
+  int get rotation => [0, 1, 4].contains(numSelected) ? 1 : 0;
+
+  final Duration opacityDuraction = Duration(milliseconds: 300);
+
+  @observable
+  String directoryString = SettingsManagerBase.instance.settings.hardware.captureLocation;
+
+  Directory get outputDir => Directory(directoryString);
+  
+  @observable
+  ObservableList<File> fileList = ObservableList<File>();
+
+  @action
+  Future<void> findImages() async {
+    fileList.clear();
+    final fileListBefore = await outputDir.list().toList();
+    final matchingFiles = fileListBefore.whereType<File>().where((file) => file.path.toLowerCase().endsWith('.jpg'));
+    for (var file in matchingFiles) { fileList.add(file); }
+  }
 
 }


### PR DESCRIPTION
I realized that sometimes you might not want to use the full functionality of the photo booth, but make use of the collage generation functionality anyway. For example when using handheld shooting and loading the images in the computer later.

The new manual collage maker screen can be entered by pressing `Ctrl + M`. It searches the photo input directory for `jpg` files and displays them in a list similar to the gallery (#95). The images from the grid list can be selected similarly to the collage maker.